### PR TITLE
Fixed constructor using names pins.

### DIFF
--- a/source/Meadow.Core/Devices/F7Micro.cs
+++ b/source/Meadow.Core/Devices/F7Micro.cs
@@ -95,14 +95,14 @@ namespace Meadow.Devices
             ushort speed = 1000
         )
         {
-            return SpiBus.From(Pins.SCK, Pins.MOSI, Pins.MISO, speed);
+            return CreateSpiBus(Pins.SCK, Pins.MOSI, Pins.MISO, speed);
         }
 
         public ISpiBus CreateSpiBus(
             IPin[] pins, ushort speed = 1000
         )
         {
-            return SpiBus.From(pins[0], pins[1], pins[2], speed);
+            return CreateSpiBus(pins[0], pins[1], pins[2], speed);
         }
 
         public ISpiBus CreateSpiBus(
@@ -112,7 +112,7 @@ namespace Meadow.Devices
             ushort speed = 1000
         )
         {
-            return CreateSpiBus(clock, mosi, miso, speed);
+            return SpiBus.From(clock, mosi, miso, speed);
         }
 
         public II2cBus CreateI2cBus(


### PR DESCRIPTION
`CreateSpiBus` using named pins was recursive.  Fixed this problem and made the default call with no parameters and the call using a pin array use the method with named pins.  This make the SPI and I2C creation methods follow the same methodology.