### PR TITLE
Remove Meadow Assemblies nuget. Meadow assemblies are now automatical…

### DIFF
--- a/source/Meadow.Core/Meadow.Core.csproj
+++ b/source/Meadow.Core/Meadow.Core.csproj
@@ -21,9 +21,6 @@
    <Nullable>enable</Nullable>
  </PropertyGroup>
  <ItemGroup>
-   <PackageReference Include="WildernessLabs.Meadow.Assemblies" Version="0.8.*" />
- </ItemGroup>
- <ItemGroup>
    <Folder Include="Gateways\Bluetooth\Definitions\" />
  </ItemGroup>
  <ItemGroup>

--- a/source/Meadow.F7/Meadow.F7.csproj
+++ b/source/Meadow.F7/Meadow.F7.csproj
@@ -21,9 +21,6 @@
    <Nullable>enable</Nullable>
  </PropertyGroup>
  <ItemGroup>
-   <PackageReference Include="WildernessLabs.Meadow.Assemblies" Version="0.8.*" Condition="'$(TargetFramework)'=='net472'" />
- </ItemGroup>
- <ItemGroup>
    <ProjectReference Include="..\Meadow.Core\Meadow.Core.csproj" />
  </ItemGroup>
  <ItemGroup>


### PR DESCRIPTION
…ly handled by the CLI

This is to fix type-forwarding conflicts between netstandard reference assemblies and Mono netstandard facades.