### PR TITLE
Align app settings with other config filenames

### DIFF
--- a/source/Meadow.Core/Configuration/ConfigurableObject.cs
+++ b/source/Meadow.Core/Configuration/ConfigurableObject.cs
@@ -70,8 +70,8 @@ namespace Meadow
         private void SetConfigRoot()
         {
             var b = new ConfigurationBuilder().SetBasePath(AppDomain.CurrentDomain.BaseDirectory);
-            b.AddYamlFile("app.settings.yaml", true);
-            b.AddJsonFile("app.settings.json", true);
+            b.AddYamlFile("app.config.yaml", true);
+            b.AddJsonFile("app.config.json", true);
             this.ConfigurationRoot = b.Build();
         }
 


### PR DESCRIPTION
Following along with an outside discussion, here's a proposal to align all the config filenames.

Proposed:
* ...
* app.**config**.yaml

Currently:
* meadow.config.yaml
* wifi.config.yaml
* app.**settings**.yaml
