### PR TITLE
[After Meadow.Contracts#34] Remove OnShutdown unused parameters

### DIFF
--- a/source/Meadow.Core/Bases/App.cs
+++ b/source/Meadow.Core/Bases/App.cs
@@ -26,7 +26,7 @@
 
         public virtual Task Initialize() { return Task.CompletedTask; }
 
-        public virtual void OnShutdown(out bool complete, Exception? e = null) { complete = true; }
+        public virtual void OnShutdown() { }
 
         public virtual void OnError(Exception e, out bool recovered) { recovered = false; }
 

--- a/source/Meadow.Core/MeadowOS.cs
+++ b/source/Meadow.Core/MeadowOS.cs
@@ -23,7 +23,6 @@
         private static ILifecycleSettings LifecycleSettings { get; set; }
 
         static bool appRunning = false;
-        static bool appShutdown = false;
 
         internal static CancellationTokenSource AppAbort = new();
 
@@ -75,7 +74,7 @@
                 Resolver.Log.Trace($"App shutting down");
 
                 AppAbort.CancelAfter(millisecondsDelay: LifecycleSettings.AppFailureRestartDelaySeconds * 1000);
-                App.OnShutdown(out appShutdown);
+                App.OnShutdown();
             }
             catch (Exception e)
             {


### PR DESCRIPTION
[Prerequisite: WildernessLabs/Meadow.Contracts#34]

After a discussion with @ctacke, it seems the [two parameters for `OnShutdown` aren't being used](https://github.com/WildernessLabs/Meadow.Core/blob/afae56e569186aafffd5bb3506abddc604b937c0/source/Meadow.Core/MeadowOS.cs#L73-L92) internally. This would remove them to avoid having to document their [lack of] use in the upcoming application lifecycle events reference.