### PR TITLE
[OS] Pause runtime main thread on app shutdown

### DIFF
--- a/source/Meadow.Core/MeadowOS.cs
+++ b/source/Meadow.Core/MeadowOS.cs
@@ -298,6 +298,7 @@
             // Do a best-attempt at freeing memory and resources
             GC.Collect(GC.MaxGeneration);
             Resolver.Log.Debug("Shutdown");
+            Thread.Sleep(Timeout.Infinite);
         }
 
         /// <summary>


### PR DESCRIPTION
We never want to exit the runtime, something Meadow OS does not support.