### PR TITLE
Second wi fi connect

### DIFF
--- a/source/Meadow.F7/Devices/Esp32Coprocessor/Esp32Coprocessor_IWiFiAdapter.cs
+++ b/source/Meadow.F7/Devices/Esp32Coprocessor/Esp32Coprocessor_IWiFiAdapter.cs
@@ -453,6 +453,7 @@ namespace Meadow.Devices
                         case StatusCodes.AccessPointNotFound:
                         case StatusCodes.AuthenticationFailed:
                         case StatusCodes.CannotConnectToAccessPoint:
+                        case StatusCodes.WiFiAlreadyStarted:
                             CurrentState = NetworkState.Error;
                             break;
                     }


### PR DESCRIPTION
Second attempt to connect to an access point respects the WiFi already started error.