### PR TITLE
Switch to logger usage

### DIFF
--- a/source/Meadow.Core/Gateways/Bluetooth/Definitions/CharacteristicBool.cs
+++ b/source/Meadow.Core/Gateways/Bluetooth/Definitions/CharacteristicBool.cs
@@ -12,7 +12,7 @@ namespace Meadow.Gateways.Bluetooth
 
         public override void HandleDataWrite(byte[] data)
         {
-            Console.WriteLine($"HandleDataWrite in {this.GetType().Name}");
+            Resolver.Log.Info($"HandleDataWrite in {this.GetType().Name}");
             RaiseValueSet(data[0] != 0);
         }
 

--- a/source/Meadow.Core/Gateways/Bluetooth/Definitions/CharacteristicInt32.cs
+++ b/source/Meadow.Core/Gateways/Bluetooth/Definitions/CharacteristicInt32.cs
@@ -12,13 +12,13 @@ namespace Meadow.Gateways.Bluetooth
 
         public override void HandleDataWrite(byte[] data)
         {
-            Console.WriteLine($"HandleDataWrite in {this.GetType().Name}");
+            Resolver.Log.Info($"HandleDataWrite in {this.GetType().Name}");
 
             // TODO: if the written data isn't 4 bytes, then what??
             // for now I'll right-pad with zeros
             if (data.Length < 4)
             {
-                Console.WriteLine($"HandleDataWrite only got {data.Length} bytes - padding");
+                Resolver.Log.Info($"HandleDataWrite only got {data.Length} bytes - padding");
                 var temp = new byte[4];
                 Array.Copy(data, temp, data.Length);
                 RaiseValueSet(BitConverter.ToInt32(temp));
@@ -27,7 +27,7 @@ namespace Meadow.Gateways.Bluetooth
             {
                 if (data.Length > 4)
                 {
-                    Console.WriteLine($"HandleDataWrite got {data.Length} bytes - using only the first 4");
+                    Resolver.Log.Info($"HandleDataWrite got {data.Length} bytes - using only the first 4");
                 }
                 RaiseValueSet(BitConverter.ToInt32(data));
             }

--- a/source/Meadow.Core/Gateways/Bluetooth/Definitions/CharacteristicString.cs
+++ b/source/Meadow.Core/Gateways/Bluetooth/Definitions/CharacteristicString.cs
@@ -13,7 +13,7 @@ namespace Meadow.Gateways.Bluetooth
 
         public override void HandleDataWrite(byte[] data)
         {
-            Console.WriteLine($"HandleDataWrite in {this.GetType().Name}");
+            Resolver.Log.Info($"HandleDataWrite in {this.GetType().Name}");
 
             RaiseValueSet(Encoding.UTF8.GetString(data));
         }

--- a/source/Meadow.Core/Hardware/Communications/SerialMessagePort.cs
+++ b/source/Meadow.Core/Hardware/Communications/SerialMessagePort.cs
@@ -206,8 +206,8 @@ namespace Meadow.Hardware
                                 //todo: should this run on a new thread?
                                 // it doesn't seem to return, otherwise
                                 System.Threading.Tasks.Task.Run(() => {
-                                    //Console.WriteLine($"raising message received, msg.length: {msg.Length}");
-                                    //Console.WriteLine($"Message:{Encoding.ASCII.GetString(msg)}");
+                                    //Resolver.Log.Info($"raising message received, msg.length: {msg.Length}");
+                                    //Resolver.Log.Info($"Message:{Encoding.ASCII.GetString(msg)}");
                                     this.RaiseMessageReceivedAndNotify(new SerialMessageData() { Message = msg });
                                 });
 
@@ -263,7 +263,7 @@ namespace Meadow.Hardware
             }
             catch(Exception ex)
             {
-                Console.WriteLine($"!! {ex.Message}");
+                Resolver.Log.Error($"!! {ex.Message}");
             }
             //TODO: figure out the IObservable when there's no change context
             //base.NotifyObservers(messageResult);

--- a/source/Meadow.Core/Hardware/Communications/SerialPortBase.cs
+++ b/source/Meadow.Core/Hardware/Communications/SerialPortBase.cs
@@ -222,7 +222,7 @@ namespace Meadow.Hardware
             catch (Exception ex)
             {
                 // ignore errors in the consumer's code
-                Console.WriteLine($"Error in BufferOverrun handler: {ex.Message}");
+                Resolver.Log.Error($"Error in BufferOverrun handler: {ex.Message}");
             }
         }
 

--- a/source/Meadow.Core/Hardware/DigitalInputPort.cs
+++ b/source/Meadow.Core/Hardware/DigitalInputPort.cs
@@ -106,7 +106,7 @@ namespace Meadow.Hardware
             {
                 var capturedLastTime = LastEventTime; // note: doing this for latency reasons. kind of. sort of. bad time good time. all time.
                 this.LastEventTime = DateTime.Now;
-                //Console.WriteLine($"event on pin: {pin.Name}, state: {state}");
+                //Resolver.Log.Info($"event on pin: {pin.Name}, state: {state}");
                 // BC 2021.05.21 b5.0: Changed this to the new result type.
                 // assuming that old state is just an inversion of the new state if date time isn't min, yeah?
                 DigitalState? old = (capturedLastTime == DateTime.MinValue) ? null : new DigitalState(!state, capturedLastTime);

--- a/source/Meadow.Core/MeadowOS.cs
+++ b/source/Meadow.Core/MeadowOS.cs
@@ -268,7 +268,7 @@
             catch (Exception ex)
             {
                 // must use Console because the logger failed
-                Console.WriteLine($"Failed to create Logger: {ex.Message}");
+                Resolver.Log.Error($"Failed to create Logger: {ex.Message}");
                 return false;
             }
 
@@ -347,7 +347,7 @@
             }
             catch (Exception e)
             {
-                Console.WriteLine(e);
+                Resolver.Log.Error(e.ToString());
                 return false;
             }
         }

--- a/source/Meadow.Core/MeadowSynchronizationContext.cs
+++ b/source/Meadow.Core/MeadowSynchronizationContext.cs
@@ -17,7 +17,7 @@ namespace Meadow
                 }
                 catch (Exception e)
                 {
-                    Console.WriteLine ($"!!! {e.GetType()}: {e.Message}");
+                    Resolver.Log.Error($"!!! {e.GetType()}: {e.Message}");
                 }
             };
             ThreadPool.QueueUserWorkItem(new WaitCallback(action.Invoke));

--- a/source/Meadow.Core/Utilities/Output.cs
+++ b/source/Meadow.Core/Utilities/Output.cs
@@ -16,7 +16,7 @@ namespace Meadow.Devices
         {
             if (test)
             {
-                Console.Write(value);
+                Resolver.Log.Info(value);
             }
         }
 
@@ -25,20 +25,20 @@ namespace Meadow.Devices
         {
             if (test)
             {
-                Console.WriteLine(value);
+                Resolver.Log.Info(value);
             }
         }
 
         [Conditional("DEBUG")]
         public static void Write(string value)
         {
-            Console.Write(value);
+            Resolver.Log.Info(value);
         }
 
         [Conditional("DEBUG")]
         public static void WriteLine(string value)
         {
-            Console.WriteLine(value);
+            Resolver.Log.Info(value);
         }
 
         /// <summary>

--- a/source/Meadow.F7/Devices/F7GPIOManager.cs
+++ b/source/Meadow.F7/Devices/F7GPIOManager.cs
@@ -37,7 +37,7 @@ namespace Meadow.Devices
             DebugFeatures = DebugFeature.None;
             DeviceChannelManager = new DeviceChannelManager();
 #if DEBUG
-            //Console.WriteLine($"DirectRegisterAccess = {DirectRegisterAccess}");
+            //Resolver.Log.Info($"DirectRegisterAccess = {DirectRegisterAccess}");
             // Adjust this during test and debug for your (developer)'s purposes.  The Conditional will turn it all off in a Release build.
             //DebugFeatures = DebugFeature.Startup | DebugFeature.PinInitilize | DebugFeature.GpioDetail;
             //            DebugFeatures = DebugFeature.GpioDetail;

--- a/source/Meadow.F7/Devices/F7GPIOManager_interrupts.cs
+++ b/source/Meadow.F7/Devices/F7GPIOManager_interrupts.cs
@@ -216,7 +216,7 @@ namespace Meadow.Devices
                 }
                 catch (Exception ex)
                 {
-                    Console.WriteLine($"IST: {ex.Message}");
+                    Resolver.Log.Error($"IST: {ex.Message}");
                     Thread.Sleep(5000);
                 }
             }

--- a/source/Meadow.F7/F7PlatformOS.Configuration.cs
+++ b/source/Meadow.F7/F7PlatformOS.Configuration.cs
@@ -119,13 +119,13 @@ namespace Meadow
                 }
                 else
                 {
-                    Console.WriteLine($"Configuration ioctl failed, result code: {updResult}");
+                    Resolver.Log.Error($"Configuration ioctl failed, result code: {updResult}");
                     result = false;
                 }
             }
             catch (Exception ex)
             {
-                Console.WriteLine($"Configuration ioctl failed: {ex.Message}");
+                Resolver.Log.Error($"Configuration ioctl failed: {ex.Message}");
                 result = false;
             }
             finally

--- a/source/Meadow.F7/Hardware/Communications/F7SerialPort.cs
+++ b/source/Meadow.F7/Hardware/Communications/F7SerialPort.cs
@@ -126,11 +126,11 @@ namespace Meadow.Hardware
 
         private void ShowSettings(Nuttx.Termios settings)
         {
-            Console.WriteLine($"  Speed: {settings.c_speed}");
-            Console.WriteLine($"  Input Flags: 0x{settings.c_iflag:x}");
-            Console.WriteLine($"  OutputFlags: 0x{settings.c_oflag:x}");
-            Console.WriteLine($"  Local Flags: 0x{settings.c_lflag:x}");
-            Console.WriteLine($"  Control Flags: 0x{settings.c_cflag:x}");
+            Resolver.Log.Info($"  Speed: {settings.c_speed}");
+            Resolver.Log.Info($"  Input Flags: 0x{settings.c_iflag:x}");
+            Resolver.Log.Info($"  OutputFlags: 0x{settings.c_oflag:x}");
+            Resolver.Log.Info($"  Local Flags: 0x{settings.c_lflag:x}");
+            Resolver.Log.Info($"  Control Flags: 0x{settings.c_cflag:x}");
         }
 
         protected override unsafe void SetHardwarePortSettings(IntPtr handle)

--- a/source/Meadow.F7/Hardware/Communications/I2cBus.cs
+++ b/source/Meadow.F7/Hardware/Communications/I2cBus.cs
@@ -59,7 +59,7 @@ namespace Meadow.Hardware
                             actual = 100000;
                         }
 
-                        Console.WriteLine($"Warning: Invalid I2C Frequency of {value}. Adjusting to {actual}");
+                        Resolver.Log.Warn($"Warning: Invalid I2C Frequency of {value}. Adjusting to {actual}");
                         _frequency = new Frequency(actual, Frequency.UnitType.Hertz);
                         break;
 

--- a/source/Meadow.F7/Interop/Interop.upd.cs
+++ b/source/Meadow.F7/Interop/Interop.upd.cs
@@ -366,7 +366,7 @@ namespace Meadow.Core
                 if (result != 0)
                 {
                     var errno = Devices.UPD.GetLastError();
-                    Console.WriteLine($"GetRegister failed: {errno}");
+                    Resolver.Log.Info($"GetRegister failed: {errno}");
                     value = (uint)result;
                     return false;
                 }
@@ -392,7 +392,7 @@ namespace Meadow.Core
                 if (result != 0)
                 {
                     var errno = Devices.UPD.GetLastError();
-                    Console.WriteLine($"SetRegister failed: {errno}");
+                    Resolver.Log.Error($"SetRegister failed: {errno}");
                     return false;
                 }
                 return true;
@@ -416,7 +416,7 @@ namespace Meadow.Core
                 var result = Interop.Nuttx.ioctl(driverHandle, UpdIoctlFn.UpdateRegister, ref update);
                 if (result != 0)
                 {
-                    Console.WriteLine($"Update failed: {result}");
+                    Resolver.Log.Error($"Update failed: {result}");
                     return false;
                 }
                 return true;

--- a/source/Meadow.F7/UPD.cs
+++ b/source/Meadow.F7/UPD.cs
@@ -43,18 +43,18 @@ namespace Meadow.Devices
             var dckcfg1 = GetRegister(STM32.RCC_BASE + STM32.RCC_DCKCFGR1_OFFSET);
             var dckcfg2 = GetRegister(STM32.RCC_BASE + STM32.RCC_DCKCFGR2_OFFSET);
 
-            Console.WriteLine("Clock Registers");
-            Console.WriteLine($"\tRCC_CR:       {cr:X8}");
-            Console.WriteLine($"\tRCC_CFGR:     {cfg:X8}");
-            Console.WriteLine($"\tRCC_AHB1RSTR: {ahb1rst:X8}");
-            Console.WriteLine($"\tRCC_AHB1ENR:  {ahb1en:X8}");
-            Console.WriteLine($"\tRCC_APB1RSTR: {apb1rst:X8}");
-            Console.WriteLine($"\tRCC_APB1ENR:  {apb1en:X8}");
-            Console.WriteLine($"\tRCC_APB2RSTR: {apb2rst:X8}");
-            Console.WriteLine($"\tRCC_APB2ENR:  {apb2en:X8}");
-            Console.WriteLine($"\tRCC_PLLCFGR:  {pllcfg:X8}");
-            Console.WriteLine($"\tRCC_DCKCFGR1: {dckcfg1:X8}");
-            Console.WriteLine($"\tRCC_DCKCFGR2: {dckcfg2:X8}");
+            Resolver.Log.Info("Clock Registers");
+            Resolver.Log.Info($"\tRCC_CR:       {cr:X8}");
+            Resolver.Log.Info($"\tRCC_CFGR:     {cfg:X8}");
+            Resolver.Log.Info($"\tRCC_AHB1RSTR: {ahb1rst:X8}");
+            Resolver.Log.Info($"\tRCC_AHB1ENR:  {ahb1en:X8}");
+            Resolver.Log.Info($"\tRCC_APB1RSTR: {apb1rst:X8}");
+            Resolver.Log.Info($"\tRCC_APB1ENR:  {apb1en:X8}");
+            Resolver.Log.Info($"\tRCC_APB2RSTR: {apb2rst:X8}");
+            Resolver.Log.Info($"\tRCC_APB2ENR:  {apb2en:X8}");
+            Resolver.Log.Info($"\tRCC_PLLCFGR:  {pllcfg:X8}");
+            Resolver.Log.Info($"\tRCC_DCKCFGR1: {dckcfg1:X8}");
+            Resolver.Log.Info($"\tRCC_DCKCFGR2: {dckcfg2:X8}");
         }
 
         public static void DumpI2CRegisters()
@@ -65,12 +65,12 @@ namespace Meadow.Devices
             var timing = UPD.GetRegister(STM32.MEADOW_I2C1_BASE + STM32.I2C_TIMINGR_OFFSET);
             var timeout = UPD.GetRegister(STM32.MEADOW_I2C1_BASE + STM32.I2C_TIMEOUTR_OFFSET);
 
-            Console.WriteLine("I2C Registers");
-            Console.WriteLine($"\tI2C_CR1:      {cr1:X8}");
-            Console.WriteLine($"\tI2C_CR2:      {cr2:X8}");
-            Console.WriteLine($"\tI2C_ISR:      {isr:X8}");
-            Console.WriteLine($"\tI2C_TIMINGR:  {timing:X8}");
-            Console.WriteLine($"\tI2C_TIMEOUTR: {timeout:X8}");
+            Resolver.Log.Info("I2C Registers");
+            Resolver.Log.Info($"\tI2C_CR1:      {cr1:X8}");
+            Resolver.Log.Info($"\tI2C_CR2:      {cr2:X8}");
+            Resolver.Log.Info($"\tI2C_ISR:      {isr:X8}");
+            Resolver.Log.Info($"\tI2C_TIMINGR:  {timing:X8}");
+            Resolver.Log.Info($"\tI2C_TIMEOUTR: {timeout:X8}");
         }
 
         public static void SetRegister(uint address, uint value)
@@ -103,7 +103,7 @@ namespace Meadow.Devices
             if (result != 0)
             {
                 var err = GetLastError();
-                Console.WriteLine($"ioctl {request} failed {err}");
+                Resolver.Log.Error($"ioctl {request} failed {err}");
                 return (int)err;
             }
             return result;
@@ -115,7 +115,7 @@ namespace Meadow.Devices
             if (result != 0)
             {
                 var err = GetLastError();
-                Console.WriteLine($"ioctl {request} failed {err}");
+                Resolver.Log.Error($"ioctl {request} failed {err}");
                 return (int)err;
             }
             return result;
@@ -127,7 +127,7 @@ namespace Meadow.Devices
             if (result != 0)
             {
                 var err = GetLastError();
-                Console.WriteLine($"ioctl {request} failed {err}");
+                Resolver.Log.Error($"ioctl {request} failed {err}");
                 return (int)err;
             }
             return result;
@@ -139,7 +139,7 @@ namespace Meadow.Devices
             if (result != 0)
             {
                 var err = GetLastError();
-                Console.WriteLine($"ioctl {request} failed {err}");
+                Resolver.Log.Error($"ioctl {request} failed {err}");
                 return (int)err;
             }
             return result;
@@ -151,7 +151,7 @@ namespace Meadow.Devices
             if (result != 0)
             {
                 var err = GetLastError();
-                Console.WriteLine($"ioctl {request} failed {err}");
+                Resolver.Log.Error($"ioctl {request} failed {err}");
                 return (int)err;
             }
             return result;
@@ -163,7 +163,7 @@ namespace Meadow.Devices
             if (result != 0)
             {
                 var err = GetLastError();
-                Console.WriteLine($"ioctl {request} failed {err}");
+                Resolver.Log.Error($"ioctl {request} failed {err}");
                 return (int)err;
             }
             return result;
@@ -176,7 +176,7 @@ namespace Meadow.Devices
             if (result != 0)
             {
                 var err = GetLastError();
-                Console.WriteLine($"ioctl {request} failed {err}");
+                Resolver.Log.Error($"ioctl {request} failed {err}");
                 return (int)err;
             }
             return result;
@@ -237,7 +237,7 @@ namespace Meadow.Devices
             if (result != 0)
             {
                 var err = GetLastError();
-                Console.WriteLine($"ioctl {request} failed {err}");
+                Resolver.Log.Error($"ioctl {request} failed {err}");
                 return (int)err;
             }
             return result;
@@ -249,7 +249,7 @@ namespace Meadow.Devices
             if (result != 0)
             {
                 var err = GetLastError();
-                Console.WriteLine($"ioctl {request} failed {err}");
+                Resolver.Log.Error($"ioctl {request} failed {err}");
                 return (int)err;
             }
             return result;
@@ -261,7 +261,7 @@ namespace Meadow.Devices
             if (result != 0)
             {
                 var err = GetLastError();
-                Console.WriteLine($"ioctl {request} failed {err}");
+                Resolver.Log.Error($"ioctl {request} failed {err}");
                 return (int)err;
             }
             return result;
@@ -273,7 +273,7 @@ namespace Meadow.Devices
             if (result != 0)
             {
                 var err = GetLastError();
-                Console.WriteLine($"ioctl {request} failed {err}");
+                Resolver.Log.Error($"ioctl {request} failed {err}");
                 return (int) err;
             }
             return result;
@@ -285,7 +285,7 @@ namespace Meadow.Devices
             if (result != 0)
             {
                 var err = GetLastError();
-                Console.WriteLine($"ioctl {request} failed {err}");
+                Resolver.Log.Error($"ioctl {request} failed {err}");
                 return (int) err;
             }
             return result;
@@ -297,7 +297,7 @@ namespace Meadow.Devices
             if (result != 0)
             {
                 var err = GetLastError();
-                Console.WriteLine($"ioctl {request} failed {err}");
+                Resolver.Log.Error($"ioctl {request} failed {err}");
                 return (int) err;
             }
             return result;
@@ -309,7 +309,7 @@ namespace Meadow.Devices
             if (result != 0)
             {
                 var err = GetLastError();
-                Console.WriteLine($"ioctl {request} failed {err}");
+                Resolver.Log.Error($"ioctl {request} failed {err}");
                 return (int)err;
             }
             return result;
@@ -321,7 +321,7 @@ namespace Meadow.Devices
             if (result != 0)
             {
                 var err = GetLastError();
-                Console.WriteLine($"ioctl {request} failed {err}");
+                Resolver.Log.Error($"ioctl {request} failed {err}");
                 return (int)err;
             }
             return result;
@@ -337,7 +337,7 @@ namespace Meadow.Devices
                 if (result != 0)
                 {
                     var err = GetLastError();
-                    Console.WriteLine($"PWM setup failed {err}");
+                    Resolver.Log.Error($"PWM setup failed {err}");
                     return false;
                 }
 

--- a/source/Tests/Core.Unit.Tests/CircularBuffer_ExtensionMethod_Tests.cs
+++ b/source/Tests/Core.Unit.Tests/CircularBuffer_ExtensionMethod_Tests.cs
@@ -21,7 +21,7 @@ namespace Core.Unit.Tests
                 buffer.Append(b);
             }
 
-            //Console.WriteLine($"Buffer.Count():{buffer.Count()}");
+            //Resolver.Log.Info($"Buffer.Count():{buffer.Count()}");
 
             byte[] searchPattern = new byte[] { 3, 4, 5 };
 


### PR DESCRIPTION
Updated most of the `Console.Write*` usage to whatever `Resolver.Log.*` call seemed appropriate.

I didn't update the uses in [ProfilerApp.cs](https://github.com/WildernessLabs/Meadow.Core/blob/develop/source/Tests/Profiler/ProfilerApp.cs) because I hadn't tested if this would have any performance impact, but it shouldn't be hard to do, if desired.