### PR TITLE
Limit build badge to develop

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 [![NuGet Badge](https://buildstats.info/nuget/Meadow)](https://www.nuget.org/packages/Meadow)
-[![Stable](https://github.com/WildernessLabs/Meadow.Core/actions/workflows/ci-build.yml/badge.svg)](https://github.com/WildernessLabs/Meadow.Core/actions/workflows/ci-build.yml)
+[![Stable](https://github.com/WildernessLabs/Meadow.Core/actions/workflows/ci-build.yml/badge.svg?branch=develop)](https://github.com/WildernessLabs/Meadow.Core/actions/workflows/ci-build.yml)
 [![License: MIT](https://img.shields.io/badge/License-Apache-green.svg)](license.txt)
 
 <img src="design/banner.jpg" style="margin-bottom:10px" />


### PR DESCRIPTION
Not sure we want to use `develop` here, but `main` is currently failing anyway.