### PR TITLE
Update RootTopic to support organization id for OtA updates

### DIFF
--- a/source/Meadow.Core/Configuration/MeadowUpdateSettings.cs
+++ b/source/Meadow.Core/Configuration/MeadowUpdateSettings.cs
@@ -10,7 +10,7 @@ internal class MeadowUpdateSettings : IUpdateSettings
     public string AuthServer { get; set; } = "https://www.meadowcloud.co";
     public int AuthPort { get; set; } = 443;
     public string Organization { get; set; } = "Default organization";
-    public string RootTopic { get; set; } = "ota;ota/{ID}/updates;{OID}/ota/{ID}/update";
+    public string RootTopic { get; set; } = "ota;ota/{ID}/updates;{OID}/ota/{ID}";
     public int CloudConnectRetrySeconds { get; set; } = 15;
     public bool UseAuthentication { get; set; } = true;
 }

--- a/source/Meadow.Core/Configuration/MeadowUpdateSettings.cs
+++ b/source/Meadow.Core/Configuration/MeadowUpdateSettings.cs
@@ -10,7 +10,7 @@ internal class MeadowUpdateSettings : IUpdateSettings
     public string AuthServer { get; set; } = "https://www.meadowcloud.co";
     public int AuthPort { get; set; } = 443;
     public string Organization { get; set; } = "Default organization";
-    public string RootTopic { get; set; } = "ota;ota/{ID}/updates";
+    public string RootTopic { get; set; } = "ota;ota/{ID}/updates;{OID}/ota/{ID}/update";
     public int CloudConnectRetrySeconds { get; set; } = 15;
     public bool UseAuthentication { get; set; } = true;
 }

--- a/source/Meadow.Core/Update/UpdateService.cs
+++ b/source/Meadow.Core/Update/UpdateService.cs
@@ -37,8 +37,6 @@ public class UpdateService : IUpdateService
 
     private const string DefaultUpdateStoreDirectoryName = "update-store";
     private const string DefaultUpdateDirectoryName = "update";
-    private const string MqttOrganizationProperty = "orgId";
-    private const string DefaultUpdateLoginApiEndpoint = "/api/devices/login/";
 
     private string UpdateDirectory { get; }
     private string UpdateStoreDirectory { get; }
@@ -134,7 +132,6 @@ public class UpdateService : IUpdateService
             var opts = new JsonSerializerOptions
             {
                 PropertyNameCaseInsensitive = true,
-
             };
 
             var info = JsonSerializer.Deserialize<UpdateMessage>(json, opts);
@@ -240,7 +237,7 @@ public class UpdateService : IUpdateService
                     {
                         Resolver.Log.Debug("Creating MQTT client options");
                         var builder = new MqttClientOptionsBuilder()
-                                        .WithTcpServer(Config.UpdateServer, Config.UpdatePort);
+                            .WithTcpServer(Config.UpdateServer, Config.UpdatePort);
 
                         if (Config.UseAuthentication)
                         {


### PR DESCRIPTION
This adds an additional MQTT topic that a device subscribes to that includes the organization id. That organization id is retrieved from the device's JWT.