### PR TITLE
Logging to Meadow.Cloud

### DIFF
--- a/source/Meadow.Core/Configuration/AppSettings.cs
+++ b/source/Meadow.Core/Configuration/AppSettings.cs
@@ -1,5 +1,6 @@
 ﻿using Meadow.Update;
 using System.Collections.Generic;
+using Meadow.Cloud;
 
 namespace Meadow
 {
@@ -8,6 +9,7 @@ namespace Meadow
         public ILoggingSettings LoggingSettings { get; }
         public ILifecycleSettings LifecycleSettings { get; }
         public IUpdateSettings UpdateSettings { get; }
+        public IMeadowCloudSettings MeadowCloudSettings { get; }
         public Dictionary<string, string> Settings { get; }
     }
 }

--- a/source/Meadow.Core/Configuration/AppSettingsParser.cs
+++ b/source/Meadow.Core/Configuration/AppSettingsParser.cs
@@ -163,18 +163,11 @@ internal static class AppSettingsParser
                     Console.WriteLine($"Unable to parse value '{settingValue}' to an int");
                 }
                 break;
-            case "Update.AuthServer":
-                settings.UpdateSettings.AuthServer = settingValue;
+            case "MeadowCloud.Hostname":
+                settings.MeadowCloudSettings.Hostname = settingValue;
                 break;
-            case "Update.AuthPort":
-                if (int.TryParse(settingValue, out int cp))
-                {
-                    settings.UpdateSettings.AuthPort = cp;
-                }
-                else
-                {
-                    Console.WriteLine($"Unable to parse value '{settingValue}' to an int");
-                }
+            case "MeadowCloud.DataHostname":
+                settings.MeadowCloudSettings.DataHostname = settingValue;
                 break;
             default:
                 if (!settings.Settings.ContainsKey(settingName))

--- a/source/Meadow.Core/Configuration/MeadowAppSettings.cs
+++ b/source/Meadow.Core/Configuration/MeadowAppSettings.cs
@@ -1,5 +1,6 @@
 ﻿using Meadow.Update;
 using System.Collections.Generic;
+using Meadow.Cloud;
 
 namespace Meadow;
 
@@ -8,5 +9,6 @@ internal class MeadowAppSettings : IAppSettings
     public ILoggingSettings LoggingSettings { get; set; } = new MeadowLoggingSettings();
     public ILifecycleSettings LifecycleSettings { get; set; } = new MeadowLifecycleSettings();
     public IUpdateSettings UpdateSettings { get; set; } = new MeadowUpdateSettings();
+    public IMeadowCloudSettings MeadowCloudSettings { get; set; } = new MeadowCloudSettings();
     public Dictionary<string, string> Settings { get; set; } = new();
 }

--- a/source/Meadow.Core/Configuration/MeadowCloudSettings.cs
+++ b/source/Meadow.Core/Configuration/MeadowCloudSettings.cs
@@ -1,0 +1,9 @@
+using Meadow.Cloud;
+
+namespace Meadow;
+
+internal class MeadowCloudSettings : IMeadowCloudSettings
+{
+    public string Hostname { get; set; } = "https://www.meadowcloud.co";
+    public string DataHostname { get; set; } = "https://dev-meadow-cloud-functions.azurewebsites.net";
+}

--- a/source/Meadow.Core/Configuration/MeadowUpdateSettings.cs
+++ b/source/Meadow.Core/Configuration/MeadowUpdateSettings.cs
@@ -7,8 +7,6 @@ internal class MeadowUpdateSettings : IUpdateSettings
     public bool Enabled { get; set; } = false;
     public string UpdateServer { get; set; } = "mqtt.meadowcloud.co";
     public int UpdatePort { get; set; } = 1883;
-    public string AuthServer { get; set; } = "https://www.meadowcloud.co";
-    public int AuthPort { get; set; } = 443;
     public string Organization { get; set; } = "Default organization";
     public string RootTopic { get; set; } = "ota;ota/{ID}/updates";
     public int CloudConnectRetrySeconds { get; set; } = 15;

--- a/source/Meadow.Core/MeadowCloudService.cs
+++ b/source/Meadow.Core/MeadowCloudService.cs
@@ -1,0 +1,161 @@
+using System;
+using System.Net;
+using System.Net.Http;
+using System.Net.Http.Headers;
+using System.Text;
+using System.Text.Json;
+using System.Text.RegularExpressions;
+using System.Threading.Tasks;
+using Meadow.Cloud;
+using Meadow.Update;
+
+namespace Meadow;
+
+public class MeadowCloudService : IMeadowCloudService
+{
+    public MeadowCloudService(IMeadowCloudSettings settings)
+    {
+        Settings = settings;
+    }
+
+    public IMeadowCloudSettings Settings { get; protected set; }
+    public string? CurrentJwt { get; protected set; }
+
+    public async Task<bool> Authenticate()
+    {
+        using (var client = new HttpClient())
+        {
+            client.Timeout = new TimeSpan(0, 15, 0);
+
+            var json = JsonSerializer.Serialize<dynamic>(new { id = Resolver.Device.Information.UniqueID.ToUpper() });
+            var content = new StringContent(json, Encoding.UTF8, "application/json");
+            
+            var endpoint = $"{Settings.Hostname}/api/devices/login";
+            Resolver.Log.Debug($"Attempting to login to {endpoint} with {json}...");
+
+            var response = await client.PostAsync(endpoint, content);
+            var responseContent = await response.Content.ReadAsStringAsync();
+
+            if (response.IsSuccessStatusCode)
+            {
+                Resolver.Log.Debug($"authentication successful. extracting token");
+                var opts = new JsonSerializerOptions
+                {
+                    PropertyNameCaseInsensitive = true,
+                };
+
+                var payload = JsonSerializer.Deserialize<MeadowCloudLoginResponseMessage>(responseContent, opts);
+
+                if (payload == null)
+                {
+                    Resolver.Log.Warn($"invalid auth payload");
+                    CurrentJwt = null;
+                    return false;
+                }
+
+                Resolver.Log.Debug($"decrypting auth payload");
+                var encryptedKeyBytes = System.Convert.FromBase64String(payload.EncryptedKey);
+
+                byte[]? decryptedKey;
+                try
+                {
+                    decryptedKey = Resolver.Device.PlatformOS.RsaDecrypt(encryptedKeyBytes);
+                }
+                catch (OverflowException)
+                {
+                    // dev note: bug in pre-0.9.6.3 on F7 will provision with a bad key and end up here
+                    // TODO: add platform and OS checking for this?
+                    Resolver.Log.Error($"RSA decrypt failure. This device likely needs to be reprovisioned.");
+                    CurrentJwt = null;
+                    return false;
+                }
+
+                // then need to call method to AES decrypt the EncryptedToken with IV
+                var encryptedTokenBytes = Convert.FromBase64String(payload.EncryptedToken);
+                var ivBytes = Convert.FromBase64String(payload.Iv);
+                var decryptedToken = Resolver.Device.PlatformOS.AesDecrypt(encryptedTokenBytes, decryptedKey, ivBytes);
+
+                CurrentJwt = System.Text.Encoding.UTF8.GetString(decryptedToken);
+
+                // trim and "unprintable character" padding.  in my testing it was a 0x05, but unsure if that's consistent, so this is safer
+                CurrentJwt = Regex.Replace(CurrentJwt, @"[^\w\.@-]", "");
+                
+                Resolver.Log.Debug($"auth token successfully received");
+                return true;
+            }
+
+            if (response.StatusCode == System.Net.HttpStatusCode.NotFound)
+            {
+                // device is likely not provisioned?
+                Resolver.Log.Warn($"Update service returned 'Not Found': this device has likely not been provisioned");
+            }
+            else
+            {
+                Resolver.Log.Warn($"Update service login returned {response.StatusCode}: {responseContent}");
+            }
+            
+            CurrentJwt = null;
+            return false;
+        }
+    }
+
+    public async Task<bool> SendLog(CloudLog log)
+    {
+        int attempt = 0;
+        int maxRetries = 1;
+        var result = false;
+        
+        retry:
+        
+        if (CurrentJwt == null)
+        {
+            await Authenticate();
+        }
+
+        using (HttpClient client = new HttpClient())
+        {
+            client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", CurrentJwt);
+
+            var payload = new
+            {
+                timestamp = log.Timestamp,
+                severity = log.Level,
+                message = log.Message
+            };
+
+            var json = JsonSerializer.Serialize(payload);
+            var content = new StringContent(json, Encoding.UTF8, "application/json");
+
+            Resolver.Log.Debug("making cloud log httprequest");
+            var response = await client.PostAsync($"{Settings.DataHostname}/api/logs", content);
+
+            if (response.IsSuccessStatusCode)
+            {
+                Resolver.Log.Debug("cloud log success");
+                result = true;
+            }
+            else if (response.StatusCode == HttpStatusCode.Unauthorized)
+            {
+                if (attempt < maxRetries)
+                {
+                    attempt++;
+                    Resolver.Log.Debug($"Unauthorized, re-authenticating");
+                    CurrentJwt = null;
+                    goto retry;
+                }
+                else
+                {
+                    Resolver.Log.Debug($"Unauthorized, exceeded {maxRetries} retry attempt(s)");
+                    result = false;
+                }
+            }
+            else
+            {
+                Resolver.Log.Debug($"send cloud log failed");
+                result = false;
+            }
+        }
+        GC.Collect();
+        return result;
+    }
+}

--- a/source/Meadow.Core/MeadowOS.cs
+++ b/source/Meadow.Core/MeadowOS.cs
@@ -7,6 +7,7 @@ using System.Linq;
 using System.Reflection;
 using System.Threading;
 using System.Threading.Tasks;
+using Meadow.Cloud;
 
 namespace Meadow;
 
@@ -24,6 +25,7 @@ public static partial class MeadowOS
     private static IApp App { get; set; }
     private static ILifecycleSettings LifecycleSettings { get; set; }
     private static IUpdateSettings UpdateSettings { get; set; }
+    private static IMeadowCloudSettings MeadowCloudSettings { get; set; }
     public static CancellationTokenSource AppAbort = new();
     public static int StartupTick { get; set; }
 
@@ -200,6 +202,7 @@ public static partial class MeadowOS
 
         LifecycleSettings = settings.LifecycleSettings;
         UpdateSettings = settings.UpdateSettings;
+        MeadowCloudSettings = settings.MeadowCloudSettings;
 
         return settings.Settings;
     }
@@ -386,6 +389,9 @@ public static partial class MeadowOS
 
             var updateService = new UpdateService(CurrentDevice.PlatformOS.FileSystem.FileSystemRoot, UpdateSettings);
             Resolver.Services.Add<IUpdateService>(updateService);
+
+            var meadowCloudService = new MeadowCloudService(MeadowCloudSettings);
+            Resolver.Services.Add<IMeadowCloudService>(meadowCloudService);
 
             Resolver.Log.Info($"Update Service is {(UpdateSettings.Enabled ? "enabled" : "disabled")}.");
             if (UpdateSettings.Enabled)

--- a/source/Meadow.Core/Update/UpdateService.cs
+++ b/source/Meadow.Core/Update/UpdateService.cs
@@ -16,7 +16,6 @@ using System.Net.Http.Headers;
 using System.Runtime.CompilerServices;
 using System.Text;
 using System.Text.Json;
-using System.Text.RegularExpressions;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -250,7 +249,7 @@ public class UpdateService : IUpdateService
                         ClientOptions = builder.Build();
                     }
 
-                    if (nic.IsConnected)
+                    if (nic != null && nic.IsConnected)
                     {
                         try
                         {

--- a/source/Tests/Core.Unit.Tests/AppConfigParserTests.cs
+++ b/source/Tests/Core.Unit.Tests/AppConfigParserTests.cs
@@ -15,7 +15,7 @@ namespace Core.Unit.Tests
             var s = AppSettingsParser.Parse(yml);
 
             Assert.True(s.UpdateSettings.Enabled);
-            Assert.Equal("https://staging.meadowcloud.dev", s.UpdateSettings.AuthServer);
+            Assert.Equal("mqtt.meadowcloud.co", s.UpdateSettings.UpdateServer);
         }
 
         [Fact]


### PR DESCRIPTION
* Create `MeadowCloudService` for Meadow.Cloud related interactions. Also, refactored `Authenticate()` into this service.
* Create `SendLog()` method to push log to Meadow.Cloud
* Create `MeadowCloudSettings`

Local testing: I sent a log every minute successfully for over two hours, re-authenticating twice after a 401. The auth tokens from the server expire after one hour, so this is expected.