### PR TITLE
Update default MQTT settings for OtA updates

### DIFF
--- a/source/Meadow.Core/Configuration/MeadowUpdateSettings.cs
+++ b/source/Meadow.Core/Configuration/MeadowUpdateSettings.cs
@@ -5,10 +5,10 @@ namespace Meadow;
 internal class MeadowUpdateSettings : IUpdateSettings
 {
     public bool Enabled { get; set; } = false;
-    public string UpdateServer { get; set; } = "mqtt.meadowcloud.co";
+    public string UpdateServer { get; set; } = "mqtt-01.meadowcloud.co";
     public int UpdatePort { get; set; } = 1883;
     public string Organization { get; set; } = "Default organization";
-    public string RootTopic { get; set; } = "ota;ota/{ID}/updates;{OID}/ota/{ID}";
+    public string RootTopic { get; set; } = "{OID}/ota/{ID}";
     public int CloudConnectRetrySeconds { get; set; } = 15;
     public bool UseAuthentication { get; set; } = true;
 }


### PR DESCRIPTION
This updates the default MQTT settings used for OtA updates for use with the new MQTT server.