### PR TITLE
set default DataHostname for production

### DIFF
--- a/source/Meadow.Core/Configuration/MeadowCloudSettings.cs
+++ b/source/Meadow.Core/Configuration/MeadowCloudSettings.cs
@@ -5,5 +5,5 @@ namespace Meadow;
 internal class MeadowCloudSettings : IMeadowCloudSettings
 {
     public string Hostname { get; set; } = "https://www.meadowcloud.co";
-    public string DataHostname { get; set; } = "https://dev-meadow-cloud-functions.azurewebsites.net";
+    public string DataHostname { get; set; } = "https://collector.meadowcloud.co";
 }


### PR DESCRIPTION
update DataHostname for CloudLogger to proper prod uri