### PR TITLE
Add support for subscribing to Meadow.Cloud commands

### DIFF
--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -26,24 +26,12 @@ jobs:
       with:
         path: Meadow.Core # we have to put this in a sub-folder so we can pull Contracts/Units to a parent folder
        
-    - name: Determine Meadow.Contracts branch to use
-      id: pick_contracts_branch
-      shell: bash
-      env:
-        BRANCH: ${{ github.head_ref || github.ref }}
-      run: |
-        if git ls-remote --exit-code --heads https://github.com/WildernessLabs/Meadow.Contracts ${BRANCH}; then
-          echo "branch=${BRANCH}" >> $GITHUB_OUTPUT
-        else
-          echo "branch=develop" >> $GITHUB_OUTPUT
-        fi
-
     - name: Checkout Meadow.Contracts
       uses: actions/checkout@v3
       with:
         repository: WildernessLabs/Meadow.Contracts
         path: Meadow.Contracts
-        ref: ${{ steps.pick_contracts_branch.outputs.branch }}
+        ref: develop
 
     - name: Checkout Meadow.Units
       uses: actions/checkout@v3

--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -26,6 +26,24 @@ jobs:
       with:
         path: Meadow.Core # we have to put this in a sub-folder so we can pull Contracts/Units to a parent folder
        
+    - name: Determine Meadow.Contracts branch to use
+      id: pick_contracts_branch
+      shell: bash
+      run: |
+        BRANCH=${GITHUB_REF#refs/heads/}
+        if git ls-remote --exit-code --heads https://github.com/WildernessLabs/Meadow.Contracts ${BRANCH}; then
+          echo "::set-output name=branch::${BRANCH}"
+        else
+          echo "::set-output name=success::develop"
+        fi
+
+    - name: Checkout Meadow.Contracts
+      uses: actions/checkout@v3
+      with:
+        repository: WildernessLabs/Meadow.Contracts
+        path: Meadow.Contracts
+        ref: ${{ steps.pick_contracts_branch.outputs.branch }}
+
     - name: Checkout Meadow.Contracts
       uses: actions/checkout@v3
       with:

--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -25,24 +25,13 @@ jobs:
       uses: actions/checkout@v3
       with:
         path: Meadow.Core # we have to put this in a sub-folder so we can pull Contracts/Units to a parent folder
-       
-    - name: Determine Meadow.Contracts branch to use
-      id: pick_contracts_branch
-      shell: bash
-      run: |
-        BRANCH=${GITHUB_REF#refs/heads/}
-        if git ls-remote --exit-code --heads https://github.com/WildernessLabs/Meadow.Contracts ${BRANCH}; then
-          echo "::set-output name=branch::${BRANCH}"
-        else
-          echo "::set-output name=success::develop"
-        fi
 
     - name: Checkout Meadow.Contracts
       uses: actions/checkout@v3
       with:
         repository: WildernessLabs/Meadow.Contracts
         path: Meadow.Contracts
-        ref: ${{ steps.pick_contracts_branch.outputs.branch }}
+        ref: testtesttest
 
     - name: Checkout Meadow.Units
       uses: actions/checkout@v3

--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -65,3 +65,6 @@ jobs:
       
     - name: Build Meadow.Core
       run: dotnet build -c Release Meadow.Core/source/Meadow.Core.sln
+    
+    - name: Test Core.Unit.Tests
+      run: dotnet test -c Release --no-build Meadow.Core/source/Tests/Core.Unit.Tests/Core.Unit.Tests.csproj

--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -25,13 +25,25 @@ jobs:
       uses: actions/checkout@v3
       with:
         path: Meadow.Core # we have to put this in a sub-folder so we can pull Contracts/Units to a parent folder
+       
+    - name: Determine Meadow.Contracts branch to use
+      id: pick_contracts_branch
+      shell: bash
+      env:
+        BRANCH: ${{ github.head_ref || github.ref }}
+      run: |
+        if git ls-remote --exit-code --heads https://github.com/WildernessLabs/Meadow.Contracts ${BRANCH}; then
+          echo "branch=${BRANCH}" >> $GITHUB_OUTPUT
+        else
+          echo "branch=develop" >> $GITHUB_OUTPUT
+        fi
 
     - name: Checkout Meadow.Contracts
       uses: actions/checkout@v3
       with:
         repository: WildernessLabs/Meadow.Contracts
         path: Meadow.Contracts
-        ref: testtesttest
+        ref: ${{ steps.pick_contracts_branch.outputs.branch }}
 
     - name: Checkout Meadow.Units
       uses: actions/checkout@v3

--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -44,13 +44,6 @@ jobs:
         path: Meadow.Contracts
         ref: ${{ steps.pick_contracts_branch.outputs.branch }}
 
-    - name: Checkout Meadow.Contracts
-      uses: actions/checkout@v3
-      with:
-        repository: WildernessLabs/Meadow.Contracts
-        path: Meadow.Contracts
-        ref: develop
-
     - name: Checkout Meadow.Units
       uses: actions/checkout@v3
       with:

--- a/source/Meadow.Core/Configuration/MeadowUpdateSettings.cs
+++ b/source/Meadow.Core/Configuration/MeadowUpdateSettings.cs
@@ -8,7 +8,7 @@ internal class MeadowUpdateSettings : IUpdateSettings
     public string UpdateServer { get; set; } = "mqtt-01.meadowcloud.co";
     public int UpdatePort { get; set; } = 1883;
     public string Organization { get; set; } = "Default organization";
-    public string RootTopic { get; set; } = "{OID}/ota/{ID}";
+    public string RootTopic { get; set; } = "{OID}/ota/{ID};{OID}/commands/{ID}";
     public int CloudConnectRetrySeconds { get; set; } = 15;
     public bool UseAuthentication { get; set; } = true;
 }

--- a/source/Meadow.Core/MeadowOS.cs
+++ b/source/Meadow.Core/MeadowOS.cs
@@ -393,6 +393,8 @@ public static partial class MeadowOS
             var meadowCloudService = new MeadowCloudService(MeadowCloudSettings);
             Resolver.Services.Add<IMeadowCloudService>(meadowCloudService);
 
+            Resolver.Services.Add<ICommandService>(updateService);
+
             Resolver.Log.Info($"Update Service is {(UpdateSettings.Enabled ? "enabled" : "disabled")}.");
             if (UpdateSettings.Enabled)
             {

--- a/source/Meadow.Core/Update/UpdateService.cs
+++ b/source/Meadow.Core/Update/UpdateService.cs
@@ -24,7 +24,6 @@ using System.Threading;
 using System.Threading.Tasks;
 
 [assembly: InternalsVisibleTo("Meadow.Update")]
-[assembly: InternalsVisibleTo("Core.Unit.Tests")]
 
 namespace Meadow.Update;
 
@@ -130,7 +129,7 @@ public class UpdateService : IUpdateService, ICommandService
         {
             Resolver.Log.Debug("MQTT message received");
 
-            if (f.ApplicationMessage.Topic.EndsWith($"/commands/{Resolver.Device.Information.UniqueID}", StringComparison.Ordinal))
+            if (f.ApplicationMessage.Topic.EndsWith($"/commands/{Resolver.Device.Information.UniqueID}", StringComparison.OrdinalIgnoreCase))
             {
                 Resolver.Log.Trace("Meadow command received");
                 ProcessPublishedCommand(f.ApplicationMessage);
@@ -670,27 +669,23 @@ public class UpdateService : IUpdateService, ICommandService
     void ICommandService.Subscribe(Action<MeadowCommand> action)
     {
         CommandSubscriptions[UntypedCommandTypeName] = (CommandType: typeof(MeadowCommand), Action: x => action((MeadowCommand)x));
-        Resolver.Log.Trace($"Command service subscribed and listening and generic Meadow command. You may publish commands to Meadow.Cloud using any command name on your choosing.");
     }
 
     void ICommandService.Subscribe<T>(Action<T> action)
     {
         var commandTypeName = typeof(T).Name;
         CommandSubscriptions[commandTypeName.ToUpperInvariant()] = (CommandType: typeof(T), Action: x => action((T)x));
-        Resolver.Log.Trace($"Command service subscribed to type '{commandTypeName}'. You may publish commands to Meadow.Cloud using '{commandTypeName}' as the command name (case insensitive).");
     }
 
     void ICommandService.Unsubscribe()
     {
         CommandSubscriptions.TryRemove(UntypedCommandTypeName, out _);
-        Resolver.Log.Trace($"Command service unsubscribed from the generic Meadow command listener.");
     }
 
     void ICommandService.Unsubscribe<T>()
     {
         var commandTypeName = typeof(T).Name;
         CommandSubscriptions.TryRemove(commandTypeName.ToUpperInvariant(), out _);
-        Resolver.Log.Trace($"Command service unsubscribed from the '{commandTypeName}' Meadow command listener.");
     }
 
     internal void ProcessPublishedCommand(MqttApplicationMessage message)

--- a/source/Tests/Core.Unit.Tests/Core.Unit.Tests.csproj
+++ b/source/Tests/Core.Unit.Tests/Core.Unit.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net7.0</TargetFramework>
 
     <IsPackable>false</IsPackable>
   </PropertyGroup>

--- a/source/Tests/Core.Unit.Tests/Core.Unit.Tests.csproj
+++ b/source/Tests/Core.Unit.Tests/Core.Unit.Tests.csproj
@@ -1,7 +1,7 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
 
     <IsPackable>false</IsPackable>
   </PropertyGroup>

--- a/source/Tests/Core.Unit.Tests/UpdateServiceTests/CommandServiceTests.cs
+++ b/source/Tests/Core.Unit.Tests/UpdateServiceTests/CommandServiceTests.cs
@@ -1,0 +1,423 @@
+﻿using Meadow;
+using Meadow.Cloud;
+using Meadow.Logging;
+using Meadow.Update;
+using MQTTnet;
+using System;
+using System.Collections.Generic;
+using System.Text;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using Xunit;
+
+namespace Core.Unit.Tests.UpdateServiceTests
+{
+    public class CommandServiceTests : IDisposable
+    {
+        private readonly TestLogProvider _log = new();
+        private readonly UpdateService _updateService = new("", null);
+
+        public CommandServiceTests()
+        {
+            Resolver.Services.GetOrCreate<Logger>();
+            Resolver.Log.LogLevel = LogLevel.Trace;
+            Resolver.Log.AddProvider(_log);
+        }
+
+        public void Dispose()
+        {
+            _log.Disable();
+        }
+
+        [Fact]
+        public void ProcessPublishedCommand_WithNullUserProperies_ShouldLogError()
+        {
+            // Arrange
+            var message = new MqttApplicationMessageBuilder()
+                .WithTopic("topic")
+                .Build();
+
+            // Act
+            _updateService.ProcessPublishedCommand(message);
+
+            // Assert
+            Assert.Contains(new LogMessage(LogLevel.Error, "Unable to process published command without a command name."), _log.LogMessages);
+        }
+
+        [Fact]
+        public void ProcessPublishedCommand_WithNoCommandNameUserPropery_ShouldLogError()
+        {
+            // Arrange
+            var message = new MqttApplicationMessageBuilder()
+                .WithTopic("topic")
+                .WithUserProperty("property", "value")
+                .Build();
+
+            // Act
+            _updateService.ProcessPublishedCommand(message);
+
+            // Assert
+            Assert.Contains(new LogMessage(LogLevel.Error, "Unable to process published command without a command name."), _log.LogMessages);
+        }
+
+        [Theory]
+        [InlineData("")]
+        [InlineData(" ")]
+        public void ProcessPublishedCommand_WithEmptyOrWhiteSpaceCommandName_ShouldLogError(string commandName)
+        {
+            // Arrange
+            var message = new MqttApplicationMessageBuilder()
+                .WithTopic("topic")
+                .WithUserProperty("commandName", commandName)
+                .Build();
+
+            // Act
+            _updateService.ProcessPublishedCommand(message);
+
+            // Assert
+            Assert.Contains(new LogMessage(LogLevel.Error, "Unable to process published command without a command name."), _log.LogMessages);
+        }
+
+        [Fact]
+        public void ProcessPublishedCommand_WithUntypedSubscriptionAndNoPayload_ShouldRunAction()
+        {
+            // Arrange
+            var message = new MqttApplicationMessageBuilder()
+                .WithTopic("topic")
+                .WithUserProperty("commandName", "exampleCommandName")
+                .Build();
+
+            ICommandService commandService = _updateService;
+            commandService.Subscribe(cmd =>
+            {
+                // Assert
+                Assert.Equal("exampleCommandName", cmd.CommandName);
+                Assert.NotNull(cmd.Arguments);
+                Assert.Empty(cmd.Arguments);
+
+                Resolver.Log.Info($"Command action was performed.");
+            });
+
+            // Act
+            _updateService.ProcessPublishedCommand(message);
+
+            // Assert 
+            Assert.Contains(new LogMessage(LogLevel.Information, "Command action was performed."), _log.LogMessages);
+        }
+
+        [Fact]
+        public void ProcessPublishCommand_WithUntypedSubscriptionAndInvalidPayload_ShouldLogError()
+        {
+            // Arrange
+            var message = new MqttApplicationMessageBuilder()
+                .WithTopic("topic")
+                .WithUserProperty("commandName", "exampleCommandName")
+                .WithPayload(Encoding.UTF8.GetBytes("[]"))
+                .Build();
+
+            ICommandService commandService = _updateService;
+            commandService.Subscribe(cmd => Resolver.Log.Info($"Command action was performed."));
+
+            // Act
+            _updateService.ProcessPublishedCommand(message);
+
+            // Assert 
+            Assert.DoesNotContain(new LogMessage(LogLevel.Information, "Command action was performed."), _log.LogMessages);
+            Assert.Contains(_log.LogMessages, msg => msg.Level == LogLevel.Error);
+        }
+
+        [Fact]
+        public void ProcessPublishedCommand_WithUntypedSubscription_ShouldRunAction()
+        {
+            // Arrange
+            var message = new MqttApplicationMessageBuilder()
+                .WithTopic("topic")
+                .WithUserProperty("commandName", "exampleCommandName")
+                .WithPayload(Encoding.UTF8.GetBytes(JsonSerializer.Serialize(new { ArgProperty = true })))
+                .Build();
+
+            ICommandService commandService = _updateService;
+            commandService.Subscribe(cmd =>
+            {
+                // Assert
+                Assert.Equal("exampleCommandName", cmd.CommandName);
+
+                Assert.NotNull(cmd.Arguments);
+                Assert.NotEmpty(cmd.Arguments);
+                Assert.Equal("True", cmd.Arguments["ArgProperty"].ToString());
+
+                Resolver.Log.Info($"Command action was performed.");
+            });
+
+            // Act
+            _updateService.ProcessPublishedCommand(message);
+
+            // Assert
+            Assert.Contains(new LogMessage(LogLevel.Information, "Command action was performed."), _log.LogMessages);
+        }
+
+        [Fact]
+        public void ProcessPublishedCommand_WithSubscribingToUntypedSubscriptionTwice_ShouldRunLastAction()
+        {
+            // Arrange
+            var message = new MqttApplicationMessageBuilder()
+                .WithTopic("topic")
+                .WithUserProperty("commandName", "exampleCommandName")
+                .Build();
+
+            ICommandService commandService = _updateService;
+            commandService.Subscribe(cmd => Resolver.Log.Info($"Command action 1 was performed."));
+            commandService.Subscribe(cmd => Resolver.Log.Info($"Command action 2 was performed."));
+
+            // Act
+            _updateService.ProcessPublishedCommand(message);
+
+            // Assert
+            Assert.Contains(new LogMessage(LogLevel.Information, "Command action 2 was performed."), _log.LogMessages);
+        }
+
+        [Fact]
+        public void ProcessPublishCommand_WithSubscribingToUntypedSubscriptionAndUnsubcribing_ShouldNotRunAction()
+        {
+            // Arrange
+            var message = new MqttApplicationMessageBuilder()
+                .WithTopic("topic")
+                .WithUserProperty("commandName", "exampleCommandName")
+                .Build();
+
+            ICommandService commandService = _updateService;
+            commandService.Subscribe(cmd => Resolver.Log.Info($"Command action was performed."));
+            commandService.Unsubscribe();
+
+            // Act
+            _updateService.ProcessPublishedCommand(message);
+
+            // Assert
+            Assert.DoesNotContain(new LogMessage(LogLevel.Information, "Command action was performed."), _log.LogMessages);
+        }
+
+        [Fact]
+        public void ProcessPublishCommand_WithTypedSubscriptionAndNoPayload_ShouldRunAction()
+        {
+            // Arrange
+            var message = new MqttApplicationMessageBuilder()
+                .WithTopic("topic")
+                .WithUserProperty("commandName", "testCommand")
+                .Build();
+
+            ICommandService commandService = _updateService;
+            commandService.Subscribe<TestCommand>(cmd =>
+            {
+                // Assert
+                Assert.NotNull(cmd);
+                Assert.False(cmd.ArgProperty);
+
+                Resolver.Log.Info($"Command action was performed.");
+            });
+
+            // Act
+            _updateService.ProcessPublishedCommand(message);
+
+            // Assert 
+            Assert.Contains(new LogMessage(LogLevel.Information, "Command action was performed."), _log.LogMessages);
+        }
+
+        [Fact]
+        public void ProcessPublishCommand_WithTypedSubscriptionAndInvalidPayload_ShouldLogError()
+        {
+            // Arrange
+            var message = new MqttApplicationMessageBuilder()
+                .WithTopic("topic")
+                .WithUserProperty("commandName", "testCommand")
+                .WithPayload(Encoding.UTF8.GetBytes("[]"))
+                .Build();
+
+            ICommandService commandService = _updateService;
+            commandService.Subscribe<TestCommand>(cmd => Resolver.Log.Info($"Command action was performed."));
+
+            // Act
+            _updateService.ProcessPublishedCommand(message);
+
+            // Assert 
+            Assert.DoesNotContain(new LogMessage(LogLevel.Information, "Command action was performed."), _log.LogMessages);
+            Assert.Contains(_log.LogMessages, msg => msg.Level == LogLevel.Error);
+        }
+
+        [Fact]
+        public void ProcessPublishCommand_WithTypedSubscription_ShouldRunAction()
+        {
+            // Arrange
+            var message = new MqttApplicationMessageBuilder()
+                .WithTopic("topic")
+                .WithUserProperty("commandName", "testCommand")
+                .WithPayload(Encoding.UTF8.GetBytes(JsonSerializer.Serialize(new { ArgProperty = true })))
+                .Build();
+
+            ICommandService commandService = _updateService;
+            commandService.Subscribe<TestCommand>(cmd =>
+            {
+                // Assert
+                Assert.NotNull(cmd);
+                Assert.True(cmd.ArgProperty);
+
+                Resolver.Log.Info($"Command action was performed.");
+            });
+
+            // Act
+            _updateService.ProcessPublishedCommand(message);
+
+            // Assert 
+            Assert.Contains(new LogMessage(LogLevel.Information, "Command action was performed."), _log.LogMessages);
+        }
+
+        [Fact]
+        public void ProcessPublishCommand_WithTypedSubscriptionAndAdditionalData_ShouldRunAction()
+        {
+            // Arrange
+            var message = new MqttApplicationMessageBuilder()
+                .WithTopic("topic")
+                .WithUserProperty("commandName", "testCommandWithExtensionData")
+                .WithPayload(Encoding.UTF8.GetBytes(JsonSerializer.Serialize(new { ArgProperty = true, AnotherProperty = "anotherValue" })))
+                .Build();
+
+            ICommandService commandService = _updateService;
+            commandService.Subscribe<TestCommandWithExtensionData>(cmd =>
+            {
+                // Assert
+                Assert.NotNull(cmd);
+                Assert.True(cmd.ArgProperty);
+                Assert.Equal("anotherValue", cmd.AdditionalData["AnotherProperty"].ToString());
+
+                Resolver.Log.Info($"Command action was performed.");
+            });
+
+            // Act
+            _updateService.ProcessPublishedCommand(message);
+
+            // Assert 
+            Assert.Contains(new LogMessage(LogLevel.Information, "Command action was performed."), _log.LogMessages);
+        }
+
+        [Fact]
+        public void ProcessPublishCommand_WithTypedAndUntypedSubscription_ShouldRunBothActions()
+        {
+            // Arrange
+            var message = new MqttApplicationMessageBuilder()
+                .WithTopic("topic")
+                .WithUserProperty("commandName", "testCommand")
+                .Build();
+
+            ICommandService commandService = _updateService;
+            commandService.Subscribe(cmd => Resolver.Log.Info($"Command action 1 was performed."));
+            commandService.Subscribe<TestCommand>(cmd => Resolver.Log.Info($"Command action 2 was performed."));
+
+            // Act
+            _updateService.ProcessPublishedCommand(message);
+
+            // Assert
+            Assert.Contains(new LogMessage(LogLevel.Information, "Command action 1 was performed."), _log.LogMessages);
+            Assert.Contains(new LogMessage(LogLevel.Information, "Command action 2 was performed."), _log.LogMessages);
+        }
+
+        [Fact]
+        public void ProcessPublishCommand_WithTypedSubscriptionAndUntypedCommandName_ShouldNotRunAction()
+        {
+            // Arrange
+            var message = new MqttApplicationMessageBuilder()
+                .WithTopic("topic")
+                .WithUserProperty("commandName", "<<<MEADOWCOMMAND>>>")
+                .Build();
+
+            ICommandService commandService = _updateService;
+            commandService.Subscribe<TestCommand>(cmd => Resolver.Log.Info($"Command action was performed."));
+
+            // Act
+            _updateService.ProcessPublishedCommand(message);
+
+            // Assert
+            Assert.DoesNotContain(new LogMessage(LogLevel.Information, "Command action was performed."), _log.LogMessages);
+        }
+
+        [Fact]
+        public void ProcessPublishCommand_WithSubscribingToTypedSubscriptionAndUnsubcribing_ShouldNotRunAction()
+        {
+            // Arrange
+            var message = new MqttApplicationMessageBuilder()
+                .WithTopic("topic")
+                .WithUserProperty("commandName", "testCommand")
+                .Build();
+
+            ICommandService commandService = _updateService;
+            commandService.Subscribe<TestCommand>(cmd => Resolver.Log.Info($"Command action was performed."));
+            commandService.Unsubscribe<TestCommand>();
+
+            // Act
+            _updateService.ProcessPublishedCommand(message);
+
+            // Assert
+            Assert.DoesNotContain(new LogMessage(LogLevel.Information, "Command action was performed."), _log.LogMessages);
+        }
+
+        [Fact]
+        public void ProcessPublishedCommand_WithSubscribingToTypedSubscriptionTwice_ShouldRunLastAction()
+        {
+            // Arrange
+            var message = new MqttApplicationMessageBuilder()
+                .WithTopic("topic")
+                .WithUserProperty("commandName", "testCommand")
+                .Build();
+
+            ICommandService commandService = _updateService;
+            commandService.Subscribe<TestCommand>(cmd => Resolver.Log.Info($"Command action 1 was performed."));
+            commandService.Subscribe<TestCommand>(cmd => Resolver.Log.Info($"Command action 2 was performed."));
+
+            // Act
+            _updateService.ProcessPublishedCommand(message);
+
+            // Assert
+            Assert.Contains(new LogMessage(LogLevel.Information, "Command action 2 was performed."), _log.LogMessages);
+        }
+
+        public class TestCommand : IMeadowCommand
+        {
+            public bool ArgProperty { get; set; }
+        }
+
+        public class TestCommandWithExtensionData : IMeadowCommand
+        {
+            public bool ArgProperty { get; set; }
+
+            [JsonExtensionData]
+            public IDictionary<string, object> AdditionalData { get; set; }
+        }
+
+        public class TestLogProvider : ILogProvider
+        {
+            private bool _isEnabled = true;
+
+            public List<LogMessage> LogMessages { get; } = new List<LogMessage>();
+
+            public void Log(LogLevel level, string message)
+            {
+                if (!_isEnabled)
+                {
+                    return;
+                }
+
+                if (string.IsNullOrWhiteSpace(message))
+                {
+                    throw new ArgumentException($"'{nameof(message)}' cannot be null or whitespace.", nameof(message));
+                }
+
+                LogMessages.Add(new LogMessage(level, message));
+            }
+
+            public void Disable()
+            {
+                _isEnabled = false;
+            }
+        }
+
+        public record LogMessage(LogLevel Level, string Message) { }
+    }
+}


### PR DESCRIPTION
This adds the implementation for the command and control feature of Meadow.Cloud. The interface and class contracts are a part of a [separate pull request in Meadow.Contracts](https://github.com/WildernessLabs/Meadow.Contracts/pull/128). The purpose of this feature is to allow a user to publish command messages to their Meadow devices and have their devices respond accordingly.