### PR TITLE
health reporter improvements and CCM batteryinfo fix

### DIFF
--- a/source/Meadow.Core/HealthReporter.cs
+++ b/source/Meadow.Core/HealthReporter.cs
@@ -55,9 +55,11 @@ public class HealthReporter : IHealthReporter
                 EventId = 10,
                 Measurements = new Dictionary<string, object>()
                 {
-                    { "cpu_temp_celsius", device.PlatformOS.GetCpuTemperature().Celsius },
-                    { "memory_used", GC.GetTotalMemory(false) },
-                    { "disk_space_used", usedDiskSpace }
+                    { "health.cpu_temp_celsius", device.PlatformOS.GetCpuTemperature().Celsius },
+                    { "health.memory_used", GC.GetTotalMemory(false) },
+                    { "health.disk_space_used", usedDiskSpace },
+                    { "info.os_version", device.Information.OSVersion },
+                    
                 },
                 Timestamp = DateTime.UtcNow
             };
@@ -65,9 +67,14 @@ public class HealthReporter : IHealthReporter
             var batteryInfo = device.GetBatteryInfo();
             if (batteryInfo != null)
             {
-                ce.Measurements.Add("battery_percentage", batteryInfo.StateOfCharge);
+                ce.Measurements.Add("health.battery_percentage", batteryInfo.StateOfCharge);
             }
 
+            if (!string.IsNullOrEmpty(device.Information.CoprocessorOSVersion))
+            {
+                ce.Measurements.Add("info.coprocessor_os_version", device.Information.CoprocessorOSVersion);
+            }
+            
             await service!.SendEvent(ce);
             Resolver.Log.Trace($"health metrics sent");
         }

--- a/source/Meadow.Core/HealthReporter.cs
+++ b/source/Meadow.Core/HealthReporter.cs
@@ -28,8 +28,10 @@ public class HealthReporter : IHealthReporter
         Resolver.Device.NetworkAdapters.NetworkConnected += async (sender, args) =>
         {
             Resolver.Log.Trace($"starting health metrics timer");
-            await Send();
             timer.Start();
+            
+            // send the first health metric
+            await Send();
         };
     }
 

--- a/source/Meadow.Core/HealthReporter.cs
+++ b/source/Meadow.Core/HealthReporter.cs
@@ -6,8 +6,6 @@ using System.Threading;
 using System.Threading.Tasks;
 using System.Timers;
 using Meadow.Cloud;
-using Meadow.Gateway.WiFi;
-using Meadow.Hardware;
 
 namespace Meadow;
 

--- a/source/Meadow.Core/HealthReporter.cs
+++ b/source/Meadow.Core/HealthReporter.cs
@@ -6,6 +6,8 @@ using System.Threading;
 using System.Threading.Tasks;
 using System.Timers;
 using Meadow.Cloud;
+using Meadow.Gateway.WiFi;
+using Meadow.Hardware;
 
 namespace Meadow;
 
@@ -15,11 +17,8 @@ namespace Meadow;
 public class HealthReporter : IHealthReporter
 {
     static SemaphoreSlim semaphoreSlim = new SemaphoreSlim(1, 1);
-
-    /// <summary>
-    /// Starts the health reporter based on the desired interval.
-    /// </summary>
-    /// <param name="interval">In minutes</param>
+    
+    /// <inheritdoc/>
     public void Start(int interval)
     {
         System.Timers.Timer timer = new(interval: interval * 60 * 1000);
@@ -28,7 +27,8 @@ public class HealthReporter : IHealthReporter
         timer.Start();
     }
 
-    private async Task TimerOnElapsed(object sender, ElapsedEventArgs e)
+    /// <inheritdoc/>
+    public async Task Send()
     {
         var connected = Resolver.Device.NetworkAdapters.Any(a => a.IsConnected);
 
@@ -69,6 +69,11 @@ public class HealthReporter : IHealthReporter
         {
             semaphoreSlim.Release();
         }
+    }
+    
+    private async Task TimerOnElapsed(object sender, ElapsedEventArgs e)
+    {
+        await Send();
     }
 
     private long DirSize(DirectoryInfo d)

--- a/source/Meadow.Core/HealthReporter.cs
+++ b/source/Meadow.Core/HealthReporter.cs
@@ -24,7 +24,13 @@ public class HealthReporter : IHealthReporter
         System.Timers.Timer timer = new(interval: interval * 60 * 1000);
         timer.Elapsed += async (sender, e) => await TimerOnElapsed(sender, e);
         timer.AutoReset = true;
-        timer.Start();
+
+        Resolver.Device.NetworkAdapters.NetworkConnected += async (sender, args) =>
+        {
+            Resolver.Log.Trace($"starting health metrics timer");
+            await Send();
+            timer.Start();
+        };
     }
 
     /// <inheritdoc/>

--- a/source/implementations/f7/Meadow.F7/Devices/F7CoreComputeBase.cs
+++ b/source/implementations/f7/Meadow.F7/Devices/F7CoreComputeBase.cs
@@ -129,9 +129,9 @@ namespace Meadow.Devices
             return PwmPort.From(pin, this.IoController, frequency, dutyCycle, inverted, false);
         }
 
-        public override BatteryInfo GetBatteryInfo()
+        public override BatteryInfo? GetBatteryInfo()
         {
-            throw new NotImplementedException();
+            return null;
         }
     }
 }

--- a/source/implementations/f7/Meadow.F7/Devices/F7FeatherV1.cs
+++ b/source/implementations/f7/Meadow.F7/Devices/F7FeatherV1.cs
@@ -45,7 +45,7 @@ namespace Meadow.Devices
         /// </summary>
         /// <returns>A BatteryInfo instance</returns>
         /// <exception cref="Exception"></exception>
-        public override BatteryInfo GetBatteryInfo()
+        public override BatteryInfo? GetBatteryInfo()
         {
             if (Coprocessor != null)
             {

--- a/source/implementations/f7/Meadow.F7/Devices/F7FeatherV2.cs
+++ b/source/implementations/f7/Meadow.F7/Devices/F7FeatherV2.cs
@@ -62,7 +62,7 @@ public partial class F7FeatherV2 : F7FeatherBase
     /// Gets a BatteryInfo instance for the current state of the platform
     /// </summary>
     /// <returns>A BatteryInfo instance</returns>
-    public override BatteryInfo GetBatteryInfo()
+    public override BatteryInfo? GetBatteryInfo()
     {
         return new BatteryInfo
         {

--- a/source/implementations/f7/Meadow.F7/Devices/F7MicroBase.cs
+++ b/source/implementations/f7/Meadow.F7/Devices/F7MicroBase.cs
@@ -46,7 +46,7 @@ public abstract partial class F7MicroBase : IF7MeadowDevice
     /// Gets the current Battery information
     /// </summary>
     /// <remarks>Override this method if you have an SMBus Smart Battery</remarks>
-    public abstract BatteryInfo GetBatteryInfo();
+    public abstract BatteryInfo? GetBatteryInfo();
 
     //==== internals
     protected NetworkAdapterCollection networkAdapters;


### PR DESCRIPTION
* start health reporter timer after network is connected.
* only send battery info if it's available on the device
* send `null` `BatteryInfo` for CCM device