### PR TITLE
MeadowOS: Add trace to catch block exception on device creation

### DIFF
--- a/source/Meadow.Core/MeadowOS.cs
+++ b/source/Meadow.Core/MeadowOS.cs
@@ -352,8 +352,9 @@ public static partial class MeadowOS
                 CurrentDevice = device;
                 Resolver.Services.Add<IMeadowDevice>(CurrentDevice);
             }
-            catch (Exception)
+            catch (Exception ex)
             {
+                Resolver.Log.Trace($"Creating instance failure : {ex.Message}");
                 return false;
             }
 


### PR DESCRIPTION
Only return false on the catch block is not a good practice, the exception may not just be the
$"Failed to create instance of '{deviceType.Name}'", and if so, the user will have a hard time to figure out which is the real issue.

I caught this because I was trying to use the lib into a container and it was not binding the `/var/lib/dbus/machine-id`. So, I had to go to the lib source code and debug it ...