### PR TITLE
Meadow.Linux: Add support for Raspberry Pi 5 pinout

### DIFF
--- a/source/implementations/linux/Meadow.Linux/Hardware/Pinouts/RaspberryPi5.cs
+++ b/source/implementations/linux/Meadow.Linux/Hardware/Pinouts/RaspberryPi5.cs
@@ -1,0 +1,19 @@
+﻿using Meadow.Hardware;
+using System.Collections;
+using System.Collections.Generic;
+
+namespace Meadow.Pinouts
+{
+    public class RaspberryPi5 : RaspberryPi
+    {
+        public RaspberryPi5()
+        {
+            // the sysfs base for the pinctrl-rpi1 is 53
+            // the gpiochip bank for pinctrl-rpi1 on rpi5 is gpiochip4
+            foreach (LinuxFlexiPin pin in this.AllPins) {
+                pin.SysFsGpio += 53;
+                pin.GpiodChip = "gpiochip4";
+            }
+        }
+    }
+}

--- a/source/implementations/linux/Meadow.Linux/SysFs/LinuxFlexiPin.cs
+++ b/source/implementations/linux/Meadow.Linux/SysFs/LinuxFlexiPin.cs
@@ -11,11 +11,11 @@ namespace Meadow
         /// <summary>
         /// The pin's sysfs GPIO number
         /// </summary>
-        public int SysFsGpio { get; }
+        public int SysFsGpio { get; internal set; }
         /// <summary>
         /// The chip name for the gpiod driver
         /// </summary>
-        public string GpiodChip { get; }
+        public string GpiodChip { get; internal set; }
         /// <summary>
         /// The pin offset for the gpiod driver
         /// </summary>


### PR DESCRIPTION
The Raspberry Pi 5 pinout is quite different from the previous versions, so we need to add a new pinout class for it. It use a in house developed silicon for I/O, the RP1 I/O controller. It's comes with a new pinctrl driver that changed the sysfs base from 0 to 53 and the gpiochip bank from gpiochip0 to gpiochip4.

However, reusing what we already have from previous versions of the Raspberry Pi we can support this in a simple way, modifying LinuxFlexiPin to allow changing the SysFsGpio and GpiodChip.