### PR TITLE
Fix disconnect wifi

### DIFF
--- a/source/implementations/f7/Meadow.F7/Devices/Esp32Coprocessor/Esp32WiFiAdapter.cs
+++ b/source/implementations/f7/Meadow.F7/Devices/Esp32Coprocessor/Esp32WiFiAdapter.cs
@@ -278,6 +278,7 @@ internal class Esp32WiFiAdapter : NetworkAdapterBase, IWiFiNetworkAdapter
 
                 break;
             case WiFiFunction.NetworkDisconnectedEvent:
+                RaiseWiFiDisconnected(statusCode, payload);
                 CurrentState = NetworkState.Disconnected;
                 break;
             case WiFiFunction.NtpUpdateEvent:
@@ -683,8 +684,6 @@ internal class Esp32WiFiAdapter : NetworkAdapterBase, IWiFiNetworkAdapter
     protected void RaiseWiFiDisconnected(StatusCodes statusCode, byte[] payload)
     {
         ClearNetworkDetails();
-        _isConnected = false;
-
         var e = new WiFiDisconnectEventArgs(statusCode);
         RaiseNetworkDisconnected();
     }
@@ -735,7 +734,7 @@ internal class Esp32WiFiAdapter : NetworkAdapterBase, IWiFiNetworkAdapter
                 case NetworkState.Disconnecting:
                     break;
                 case NetworkState.Disconnected:
-                    RaiseNetworkDisconnected();
+                    _isConnected = false;
                     break;
                 case NetworkState.Error:
                     break;


### PR DESCRIPTION
## Summary
 I created an app to test the WiFi connection, but when F7 disconnected to the Access Point the variable Is Connected still was true even after receiving the NetworkDisconnected event.


```
Meadow StdOut: Try connecting ...
Meadow StdOut: Try connecting ...
Meadow StdOut: Connected :) | 0
Meadow StdOut: Connected :) | 1
Meadow StdOut: WiFi connected.
Meadow StdOut: Connected :) | 2
Meadow StdOut: Connected :) | 3
Meadow StdOut: Connected :) | 4
...
Meadow StdOut: Connected :) | 20
Meadow StdOut: WiFi disconnected.
Meadow StdOut: Connected :) | 0
Meadow StdOut: Connected :) | 1
Meadow StdOut: Connected :) | 2
Meadow StdOut: Connected :) | 3
Meadow StdOut: Connected :) | 4
...
```
