### PR TITLE
Update MQTT settings to TLS by default

### DIFF
--- a/source/Meadow.Core/Configuration/MeadowUpdateSettings.cs
+++ b/source/Meadow.Core/Configuration/MeadowUpdateSettings.cs
@@ -5,8 +5,8 @@ namespace Meadow;
 internal class MeadowUpdateSettings : IUpdateSettings
 {
     public bool Enabled { get; set; } = false;
-    public string UpdateServer { get; set; } = "mqtt-01.meadowcloud.co";
-    public int UpdatePort { get; set; } = 1883;
+    public string UpdateServer { get; set; } = "mqtt.meadowcloud.co";
+    public int UpdatePort { get; set; } = 8883;
     public string Organization { get; set; } = "Default organization";
     public string RootTopic { get; set; } = "{OID}/ota/{ID};{OID}/commands/{ID}";
     public int CloudConnectRetrySeconds { get; set; } = 15;

--- a/source/Meadow.Core/Update/UpdateService.cs
+++ b/source/Meadow.Core/Update/UpdateService.cs
@@ -277,6 +277,10 @@ public class UpdateService : IUpdateService, ICommandService
                         Resolver.Log.Debug("Creating MQTT client options");
                         var builder = new MqttClientOptionsBuilder()
                             .WithTcpServer(Config.UpdateServer, Config.UpdatePort)
+                            .WithTls(tlsParameters =>
+                            {
+                                tlsParameters.UseTls = Config.UpdatePort == 8883;
+                            })
                             .WithProtocolVersion(MQTTnet.Formatter.MqttProtocolVersion.V500)
                             .WithCommunicationTimeout(TimeSpan.FromSeconds(30));
 


### PR DESCRIPTION
This updates the MQTT settings for the UpdateService and CommandService for OtA and Command/Control, respectively, to use TLS by default.