### PR TITLE
Re-authenticate with server after timeout

### DIFF
--- a/source/Meadow.Core/Update/UpdateService.cs
+++ b/source/Meadow.Core/Update/UpdateService.cs
@@ -431,6 +431,12 @@ public class UpdateService : IUpdateService, ICommandService
             throw new ArgumentException($"Cannot find update with ID {updateInfo.ID}");
         }
 
+        // check if we need to re-authenticate with the server before starting download. 
+        if (ShouldAuthenticate())
+        {
+            AuthenticateWithServer().Wait();
+        }
+
         if (message != null)
         {
             Task.Run(() => DownloadProc(message));


### PR DESCRIPTION
Possible fix for issue Update Service state machine does not refresh token #414. 

Attempts to re-authenticate prior to download if token already expired.

Only a partial fix as it does not address the situation where the OTA server has expired before the device. e.g. time difference between server and device or server restarted or some other change that causes the previous authentication to become invalid. 

Maybe can call the `AuthenticateWithServer().Wait();` in the Exception handler when the authentication fails. 