### PR TITLE
Updating Network Status when the Default Connection started.

### DIFF
--- a/source/implementations/f7/Meadow.F7/Devices/Esp32Coprocessor/Esp32WiFiAdapter.cs
+++ b/source/implementations/f7/Meadow.F7/Devices/Esp32Coprocessor/Esp32WiFiAdapter.cs
@@ -612,7 +612,24 @@ internal class Esp32WiFiAdapter : NetworkAdapterBase, IWiFiNetworkAdapter
             throw new InvalidOperationException($"Already connected or connecting to an access point, current state {CurrentState}");
         }
 
+        CurrentState = NetworkState.Connecting;
         _esp32.SendCommand((byte)Esp32Interfaces.WiFi, (UInt32)WiFiFunction.ConnectToDefaultAccessPoint, false, null);
+
+        Task.Run(async () =>
+        {
+            var t = 0;
+            var timeout = MaximumRetryCount * 3500;
+
+            while (CurrentState == NetworkState.Connecting)
+            {
+                await Task.Delay(3500);
+                t += 3500;
+                if ((t > timeout))
+                {
+                    CurrentState = NetworkState.Disconnected;
+                }
+            }
+        });
     }
 
     /// <summary>


### PR DESCRIPTION
# Summary
The aim is to update network status when the Default Connection proceeds starting, this way,  avoid taking a long time waiting for Auto-Connect to complete when the `Connect` method is called.

Respective issue :
- https://github.com/WildernessLabs/Meadow_Issues/issues/396