### PR TITLE
Adjust cell error messages, and cell signal quality return type

### DIFF
--- a/source/implementations/f7/Meadow.F7/Devices/F7CellNetworkAdapter.cs
+++ b/source/implementations/f7/Meadow.F7/Devices/F7CellNetworkAdapter.cs
@@ -70,6 +70,7 @@ internal unsafe class F7CellNetworkAdapter : NetworkAdapterBase, ICellNetworkAda
 
     /// <summary>
     /// Get the cell module AT commands output <b>AtCmdsOutput</b> at the connection time, and then cache it.
+    /// Avoid calling this method during operations such as scanning networks or fetching signal quality to prevent interference with ongoing processes.
     /// </summary>
     private void UpdateAtCmdsOutput()
     {
@@ -233,6 +234,7 @@ internal unsafe class F7CellNetworkAdapter : NetworkAdapterBase, ICellNetworkAda
 
     /// <summary>
     /// Returns the cell module AT commands output <b>AtCmdsOutput</b> if the device tried to connect at least once, otherwise an empty string
+    /// Avoid calling this method during operations such as scanning networks or fetching signal quality to prevent interference with ongoing processes.
     /// </summary>
     public string AtCmdsOutput
     {
@@ -285,8 +287,8 @@ internal unsafe class F7CellNetworkAdapter : NetworkAdapterBase, ICellNetworkAda
     {
         int errno = Core.Interop.Nuttx.meadow_get_cell_error();
 
-        var logInfoMessage = AtCmdsOutput.Length > 1 // To avoid logging potential residual data from UART
-            ? $"You can also look at the AT commands logs for extra information: {AtCmdsOutput}"
+        var logInfoMessage = _at_cmds_output?.Length > 1 // To avoid logging potential residual data from UART
+            ? $"You can also look at the AT commands logs for extra information: {_at_cmds_output}"
             : "";
 
         CellError cellError = (CellError)errno;
@@ -353,6 +355,7 @@ internal unsafe class F7CellNetworkAdapter : NetworkAdapterBase, ICellNetworkAda
 
         while (timeout > 0)
         {
+            // Ensure that the _at_cmds_output is not updated by another method while waiting for the signal quality value
             if (_at_cmds_output != string.Empty)
             {
                 break;
@@ -389,6 +392,7 @@ internal unsafe class F7CellNetworkAdapter : NetworkAdapterBase, ICellNetworkAda
 
         while (timeout > 0)
         {
+            // Ensure that the _at_cmds_output is not updated by another method while waiting for the cell network's output
             if (_at_cmds_output != string.Empty)
             {
                 break;
@@ -425,6 +429,7 @@ internal unsafe class F7CellNetworkAdapter : NetworkAdapterBase, ICellNetworkAda
         //ToDo: switch to TimeSpan
         while (timeout > 0)
         {
+            // Ensure that the _at_cmds_output is not updated by another method while waiting for the GNSS fixes
             if (_at_cmds_output != string.Empty)
             {
                 break;

--- a/source/implementations/f7/Meadow.F7/Devices/F7CellNetworkAdapter.cs
+++ b/source/implementations/f7/Meadow.F7/Devices/F7CellNetworkAdapter.cs
@@ -185,9 +185,9 @@ internal unsafe class F7CellNetworkAdapter : NetworkAdapterBase, ICellNetworkAda
     }
 
     /// <summary>
-    /// Returns the cell signal quality <b>CSQ</b> at the connection time, if the device is connected, otherwise an empty string
+    /// Returns the cell signal quality <b>CSQ</b> at the connection time, if the device is connected, otherwise 99
     /// </summary>
-    public string Csq
+    public int Csq
     {
         get
         {
@@ -205,7 +205,7 @@ internal unsafe class F7CellNetworkAdapter : NetworkAdapterBase, ICellNetworkAda
                 }
             }
 
-            return _csq ?? string.Empty;
+            return int.Parse(_csq ?? "99");
         }
     }
 
@@ -311,7 +311,7 @@ internal unsafe class F7CellNetworkAdapter : NetworkAdapterBase, ICellNetworkAda
     /// </summary>
     /// <param name="timeout">Timeout to check signal quality.</param>
     /// <returns>A decimal number (0-31) representing the Cell Signal Quality (CSQ), or 99 if unavailable.</returns>
-    public double GetSignalQuality(int timeout)
+    public int GetSignalQuality(int timeout)
     {
         Resolver.Log.Trace("Fetching cellular signal quality... It might take a few minutes and temporary disconnect you from the cellular network.");
 
@@ -340,12 +340,7 @@ internal unsafe class F7CellNetworkAdapter : NetworkAdapterBase, ICellNetworkAda
         }
 
         var csq = ExtractValue(_at_cmds_output, csqPattern);
-        if (csq == null)
-        {
-            return 99;
-        }
-
-        return Convert.ToDouble(csq);
+        return int.Parse(csq ?? "99");
     }
 
     /// <summary>

--- a/source/implementations/f7/Meadow.F7/Interop/Interop.cell.cs
+++ b/source/implementations/f7/Meadow.F7/Interop/Interop.cell.cs
@@ -17,15 +17,12 @@ internal static partial class Interop
         public static extern int meadow_get_cell_at_cmds_output(IntPtr buf);
 
         [DllImport(LIBRARY_NAME, SetLastError = true)]
-        public static extern int meadow_cell_scanner(IntPtr buf);
-
-        [DllImport(LIBRARY_NAME, SetLastError = true)]
         public static extern void meadow_cell_change_state(int s);
 
         [DllImport(LIBRARY_NAME, SetLastError = true)]
         public static extern int meadow_get_cell_error();
 
-        public static List<CellNetwork>? Parse(string input)
+        public static List<CellNetwork>? ParseCellNetworkScannerOutput(string input)
         {
             if (input.Contains("+CME ERROR"))
             {
@@ -80,36 +77,6 @@ internal static partial class Interop
             }
 
             return cellNetworks;
-        }
-
-        public static unsafe CellNetwork[] MeadowCellNetworkScanner()
-        {
-            var buffer = Marshal.AllocHGlobal(1024);
-
-            try
-            {
-                Resolver.Log.Info("Scanning cell networks, it might take a few minutes...");
-                var len = meadow_cell_scanner(buffer);
-                if (len > 0)
-                {
-                    var data = Encoding.UTF8.GetString((byte*)buffer.ToPointer(), len);
-
-                    return Parse(data).ToArray();
-                }
-                else
-                {
-                    throw new System.IO.IOException("No available networks found, please ensure that your device is in scanning mode.");
-                }
-            }
-            catch (Exception ex)
-            {
-                Resolver.Log.Error($"No available networks found: {ex.Message}");
-                return Array.Empty<CellNetwork>();
-            }
-            finally
-            {
-                Marshal.FreeHGlobal(buffer);
-            }
         }
     }
 }

--- a/source/implementations/f7/Meadow.F7/Interop/Interop.cell.cs
+++ b/source/implementations/f7/Meadow.F7/Interop/Interop.cell.cs
@@ -57,8 +57,8 @@ internal static partial class Interop
                     mode = modeValue switch
                     {
                         0 => CellNetworkMode.GSM,
-                        7 or 8 => CellNetworkMode.CAT_M1,
-                        9 => CellNetworkMode.NB_IoT,
+                        7 or 8 => CellNetworkMode.CATM1,
+                        9 => CellNetworkMode.NBIOT,
                         _ => CellNetworkMode.GSM,
                     };
                 }


### PR DESCRIPTION
- https://github.com/WildernessLabs/Meadow.Contracts/pull/203

**Summary**
- Adjust cell error messages
- Change `Csq` property, and `GetSignalQuality` types to `int`
- Retrieve signal quality in `dBm`
- Deprecate the old network scanner method (`OfflineNetworkScan`)
- Remove underscore from network mode types, to keep consistency with the OS side.