### PR TITLE
Add network deadlock status code

### DIFF
--- a/source/implementations/f7/Meadow.F7/Devices/Esp32Coprocessor/Esp32SystemErrorInfo.cs
+++ b/source/implementations/f7/Meadow.F7/Devices/Esp32Coprocessor/Esp32SystemErrorInfo.cs
@@ -24,6 +24,7 @@ public class Esp32SystemErrorInfo : MeadowSystemErrorInfo
                 StatusCodes.InvalidConfigurationFile => "Invalid configuration file",
                 StatusCodes.InvalidWiFiConfigurationFile => "Invalid WiFi configuration file",
                 StatusCodes.InvalidCellConfigurationFile => "Invalid Cell configuration file",
+                StatusCodes.NetworkDeadlock => "Network deadlock detected. Device reboot is required to reconnect",
                 _ => "ESP32 Error"
             },
             SystemErrorNumber.CoprocessorError)

--- a/source/implementations/f7/Meadow.F7/Devices/Esp32Coprocessor/SharedEnums.cs
+++ b/source/implementations/f7/Meadow.F7/Devices/Esp32Coprocessor/SharedEnums.cs
@@ -189,7 +189,10 @@ public enum StatusCodes
     /// Cell configuration contains one or more errors.
     /// </summary>
     InvalidCellConfigurationFile = 45,
-
+    /// <summary>
+    /// Network deadlock detected.
+    /// </summary>
+    NetworkDeadlock = 46,
     /// <summary>
     /// ESP reset for unknown reason
     /// </summary>


### PR DESCRIPTION
- https://github.com/WildernessLabs/Meadow_Issues/issues/622
- https://github.com/WildernessLabs/Meadow/pull/604
- https://github.com/WildernessLabs/Meadow-ESP32/pull/76

Add network deadlock status code to keep the consistency between the OS and ESP32 `SharedEnums`.