### PR TITLE
Fix empty bearer requests issue

### DIFF
--- a/source/Meadow.Core/Cloud/MeadowCloudConnectionService.cs
+++ b/source/Meadow.Core/Cloud/MeadowCloudConnectionService.cs
@@ -756,9 +756,11 @@ internal class MeadowCloudConnectionService : IMeadowCloudService
 
             if (Settings.UseAuthentication)
             {
-                if (_jwt == null)
+                if (await Authenticate() == false)
                 {
-                    await Authenticate();
+                    Resolver.Log.Error($"Failed to authenticate with Meadow.Cloud. Retrying in {Settings.ConnectRetrySeconds} seconds...");
+                    await Task.Delay(TimeSpan.FromSeconds(Settings.ConnectRetrySeconds));
+                    goto retry;
                 }
                 client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", _jwt);
             }


### PR DESCRIPTION
**Summary**
When the `Authenticate()` fails in the `Send<T>` task, Meadow.Core attempts to make requests with an empty `_jwt`, which will always fail, and retrieve `InternalServerError` from the server. So, this PR aims to retry the authentication when it fails.