### PR TITLE
Ensure cleared path when starting new settings group

### DIFF
--- a/source/Meadow.Core/Configuration/AppSettingsParser.cs
+++ b/source/Meadow.Core/Configuration/AppSettingsParser.cs
@@ -62,6 +62,7 @@ internal static class AppSettingsParser
                         if (indent == 0)
                         {
                             level = 0;
+                            parents.Clear();
                         }
                         else if (indent > lastIndent)
                         {

--- a/source/Tests/Core.Unit.Tests/AppConfigParserTests.cs
+++ b/source/Tests/Core.Unit.Tests/AppConfigParserTests.cs
@@ -66,5 +66,27 @@ namespace Core.Unit.Tests
 
             // no error means pass
         }
+
+        [Fact]
+        public void CustomSettings()
+        {
+            var yml = File.ReadAllText("app.config.customsettings.yaml");
+
+            var s = AppSettingsParser.Parse(yml);
+
+            Assert.Equal("Expected1", s.Settings["CustomSettings.Setting1"]);
+            Assert.Equal("Expected2", s.Settings["CustomSettings.Setting2"]);
+        }
+
+        [Fact]
+        public void CustomSettingsAfterEmptySettings()
+        {
+            var yml = File.ReadAllText("app.config.customsettingsafterempty.yaml");
+
+            var s = AppSettingsParser.Parse(yml);
+
+            Assert.Equal("Expected1", s.Settings["CustomSettings.Setting1"]);
+            Assert.Equal("Expected2", s.Settings["CustomSettings.Setting2"]);
+        }
     }
 }

--- a/source/Tests/Core.Unit.Tests/Core.Unit.Tests.csproj
+++ b/source/Tests/Core.Unit.Tests/Core.Unit.Tests.csproj
@@ -25,6 +25,12 @@
     <ProjectReference Include="..\..\Meadow.Core\Meadow.Core.csproj" />
   </ItemGroup>
   <ItemGroup>
+    <None Update="app.config.customsettingsafterempty.yaml">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </None>
+    <None Update="app.config.customsettings.yaml">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </None>
     <None Update="app.config.envizor.yaml">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </None>

--- a/source/Tests/Core.Unit.Tests/app.config.customsettings.yaml
+++ b/source/Tests/Core.Unit.Tests/app.config.customsettings.yaml
@@ -1,0 +1,14 @@
+﻿Lifecycle:
+    RestartOnAppFailure: false
+    AppFailureRestartDelaySeconds: 15
+
+Logging:
+  LogLevel:
+    Default: Debug
+
+MeadowCloud:
+    CloudSetting: true
+
+CustomSettings:
+    Setting1: Expected1
+    Setting2: Expected2

--- a/source/Tests/Core.Unit.Tests/app.config.customsettingsafterempty.yaml
+++ b/source/Tests/Core.Unit.Tests/app.config.customsettingsafterempty.yaml
@@ -1,0 +1,15 @@
+﻿Lifecycle:
+    RestartOnAppFailure: false
+    AppFailureRestartDelaySeconds: 15
+
+Logging:
+  LogLevel:
+    Default: Debug
+
+MeadowCloud:
+    # CloudSetting: true
+    # All the settings in this group are commented out
+
+CustomSettings:
+    Setting1: Expected1
+    Setting2: Expected2


### PR DESCRIPTION
Following [this suggestion](https://github.com/WildernessLabs/Meadow_Issues/issues/718#issuecomment-2168057251), I started reading my custom settings directly from `IApp.Settings`. But I noticed that the keys for my settings weren't as expected. 

With the following configuration:
```yaml
MeadowCloud:
    # Enable Logging, Events, Command + Control
    Enabled: false

MyApp:
    Setting1: test1
    Setting2: test2
```

My custom settings keys were prefixed with `MyApp` (e.g., `MyApp.Setting1`). However, if I comment out all the settings in the previous section:

```yaml
MeadowCloud:
    # Enable Logging, Events, Command + Control
    # Enabled: false

MyApp:
    Setting1: test1
    Setting2: test2
```

My custom settings keys were now prefixed with `MeadowCloud.MyApp`, and my code to retrieve them failed with a `KeyNotFoundException`. 

The changes in this PR reset the settings level breadcrumbs when a new section starts, resulting in the expected key prefix for the setting.