### PR TITLE
improve connection eventing on cell

### DIFF
--- a/Source/implementations/f7/Meadow.F7/Devices/Esp32Coprocessor/SharedEnums.cs
+++ b/Source/implementations/f7/Meadow.F7/Devices/Esp32Coprocessor/SharedEnums.cs
@@ -577,6 +577,15 @@ public enum CellFunction
     /// CellFunction - NtpUpdateEvent
     /// </summary>
     NtpUpdateEvent = 5,
+    /// <summary>
+    /// CellFunction - NetworkConnectingEvent
+    /// </summary>
+    NetworkConnectingEvent = 8,
+
+    /// <summary>
+    /// CellFunction - NetworkRetryExceededEvent
+    /// </summary>
+    NetworkRetryExceededEvent = 9,
 };
 
 /// <summary>

--- a/Source/implementations/f7/Meadow.F7/Devices/F7CellNetworkAdapter.cs
+++ b/Source/implementations/f7/Meadow.F7/Devices/F7CellNetworkAdapter.cs
@@ -178,6 +178,14 @@ internal unsafe class F7CellNetworkAdapter : NetworkAdapterBase, ICellNetworkAda
             case CellFunction.NtpUpdateEvent:
                 RaiseNtpTimeChangedEvent();
                 break;
+            case CellFunction.NetworkConnectingEvent:
+                Resolver.Log.Trace("Cell connecting event triggered!");
+                RaiseNetworkConnecting();
+                break;
+            case CellFunction.NetworkRetryExceededEvent:
+                Resolver.Log.Trace("Cell retry exceeded event triggered!");
+                RaiseConnectFailed();
+                break;
             default:
                 Resolver.Log.Trace("Event type not found");
                 break;


### PR DESCRIPTION
# Summary
The PR aims to add two new events on the cell (Connecting and RetryExceeded).
Meadow PR :
-  https://github.com/WildernessLabs/Meadow/pull/627 
Issue :
- https://github.com/WildernessLabs/Meadow_Issues/issues/641

# Test
```
Cell InvokeEvent NetworkConnectingEvent returned CompletedOk
Cell connecting event triggered!
Cell network connecting!
Cell connect script failed, retrying...
Cell connect script failed, retrying...
Cell connect script failed, retrying...
Cell connect script failed, retrying...
Cell connect script failed, retrying...
Cell connect script failed, retrying...
Cell connect script failed, retrying...
Cell connect script failed, retrying...
Cell connect script failed, retrying...
Cell connect script failed, retrying...
Cell connect script failed, retrying...
Cell connect script failed, retrying...
Cell connect script failed, retrying...
Cell connect script failed, retrying...
Cell connect script failed, retrying...
Cell InvokeEvent NetworkRetryExceededEvent returned CompletedOk
Cell retry exceeded event triggered!
Cell network connect failed!

```