### PR TITLE
Remove duplicate ethernet adapter

### DIFF
--- a/Source/implementations/f7/Meadow.F7/Devices/F7CoreComputeBase.cs
+++ b/Source/implementations/f7/Meadow.F7/Devices/F7CoreComputeBase.cs
@@ -27,12 +27,6 @@ public abstract partial class F7CoreComputeBase : F7MicroBase, IF7CoreComputeMea
         : base(ioController, analogCapabilities, networkCapabilities, storageCapabilities)
     {
         Pins = pins;
-
-        if (PlatformOS.SelectedNetwork == IPlatformOS.NetworkConnectionType.Ethernet)
-        {
-            Resolver.Log.Info($"Device is configured to use Wired Ethernet for the network interface");
-            networkAdapters.Add(new WiredNetworkAdapter());
-        }
     }
 
     /// <inheritdoc/>


### PR DESCRIPTION
- https://github.com/WildernessLabs/Meadow_Issues/issues/725

This PR aims to remove a duplicated ethernet adapter:

```
Meadow StdOut: adapter: Meadow.Devices.WiredNetworkAdapter
Meadow StdOut: adapter: Meadow.Devices.F7EthernetNetworkAdapter
```

It explains why the subscribed methods are not being called when the NetworkConnected event is triggered. Basically, when the user does:

`var ethernet = Device.NetworkAdapters.Primary<IWiredNetworkAdapter>();`

It retrieves one of the adapters, which is not necessarily the one used for handling events.