### PR TITLE
Add more exception data to the OTA download error message

### DIFF
--- a/Source/Meadow.Core/Cloud/MeadowCloudUpdateService.cs
+++ b/Source/Meadow.Core/Cloud/MeadowCloudUpdateService.cs
@@ -305,7 +305,7 @@ internal class MeadowCloudUpdateService : IUpdateService
                 sw.Stop();
 
                 // TODO: raise some event?
-                Resolver.Log.Error($"Failed to download Update after {sw.Elapsed.TotalSeconds:0} seconds: {ex.Message}");
+                Resolver.Log.Error($"[ {ex.GetType().Name} ] Failed to download Update after {sw.Elapsed.TotalSeconds:0} seconds: {ex.Message} {ex.StackTrace}");
 
                 Resolver.Log.Info($"Retrying attempt {retryCount + 1} of {MaxDownloadRetries} in {RetryDelayMilliseconds} milliseconds...");
                 await Task.Delay(RetryDelayMilliseconds);


### PR DESCRIPTION
- Add more exception data to the OTA download error message

More context can be seen in the [private slack discussion](https://wildernesslabs.slack.com/archives/CFNK2MFTR/p1724806505576009).