### PR TITLE
Allow the user to set the company assigned number.

### DIFF
--- a/Source/Meadow.Core/Gateways/Bluetooth/Definitions/Definition.cs
+++ b/Source/Meadow.Core/Gateways/Bluetooth/Definitions/Definition.cs
@@ -11,6 +11,11 @@ public class Definition : IDefinition
     public string DeviceName { get; }
 
     /// <summary>
+    /// Gets the company ID.
+    /// </summary>
+    public UInt16? CompanyId { get; }
+
+    /// <summary>
     /// Gets the collection of services associated with this device definition.
     /// </summary>
     public ServiceCollection Services { get; }
@@ -23,6 +28,21 @@ public class Definition : IDefinition
     public Definition(string deviceName, params IService[] services)
     {
         DeviceName = deviceName;
+        CompanyId = null;
+        Services = new ServiceCollection();
+        Services.AddRange(services);
+    }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="Definition"/> class with the specified device name and services.
+    /// </summary>
+    /// <param name="companyId">The company ID (assigned number).</param>
+    /// <param name="deviceName">The name of the device.</param>
+    /// <param name="services">The services associated with the device.</param>
+    public Definition(UInt16 companyId, string deviceName, params IService[] services)
+    {
+        DeviceName = deviceName;
+        CompanyId = companyId;
         Services = new ServiceCollection();
         Services.AddRange(services);
     }
@@ -37,6 +57,11 @@ public class Definition : IDefinition
         var json = $@"{{
                         ""deviceName"":""{DeviceName}""
                     ";
+
+        if (CompanyId != null)
+        {
+            json += $@", ""companyIdentifier"":{CompanyId}";
+        }
 
         if (Services != null && Services.Count > 0)
         {

--- a/Source/Meadow.Core/Gateways/Bluetooth/Definitions/Definition.cs
+++ b/Source/Meadow.Core/Gateways/Bluetooth/Definitions/Definition.cs
@@ -13,7 +13,7 @@ public class Definition : IDefinition
     /// <summary>
     /// Gets the company ID.
     /// </summary>
-    public UInt16? CompanyId { get; }
+    public ushort? CompanyId { get; }
 
     /// <summary>
     /// Gets the collection of services associated with this device definition.
@@ -39,7 +39,7 @@ public class Definition : IDefinition
     /// <param name="companyId">The company ID (assigned number).</param>
     /// <param name="deviceName">The name of the device.</param>
     /// <param name="services">The services associated with the device.</param>
-    public Definition(UInt16 companyId, string deviceName, params IService[] services)
+    public Definition(ushort companyId, string deviceName, params IService[] services)
     {
         DeviceName = deviceName;
         CompanyId = companyId;


### PR DESCRIPTION
Allow the user to specify the company identifier assigned number for Bluetooth interface.

Resolves issue https://github.com/WildernessLabs/Meadow_Issues/issues/210