### PR TITLE
Check which GPIO pins file to use on a Raspberry Pi 5

### DIFF
--- a/Source/implementations/linux/Meadow.Linux/Hardware/Platforms/Raspberry Pi/RaspberryPiPinout.cs
+++ b/Source/implementations/linux/Meadow.Linux/Hardware/Platforms/Raspberry Pi/RaspberryPiPinout.cs
@@ -10,7 +10,8 @@ public class RaspberryPiPinout : PinDefinitionBase, IPinDefinitions
     internal RaspberryPiPinout() { }
 
     internal const string GpiodChipPi4 = "gpiochip0";
-    internal const string GpiodChipPi5 = "gpiochip4";
+    internal const string GpiodChipPi5_4 = "gpiochip4";
+    internal const string GpiodChipPi5_0 = "gpiochip0";
 
     internal string GpiodChipName { get; } = "gpiochip0";
     internal int SysFsOffset { get; }


### PR DESCRIPTION
When the Raspberry Pi 5 was released, the file to read pins from was changed to `gpiochip4`. After updating to version version 6.6.45 it was changed back to `gpiochip0` (same as Raspberry Pi 4 and earlier). This commit checks which file exists and loads from that one instead.

Without this change, if a new application is made today on a version of the Raspberry Pi 5 Kernel 6.6.45 or newer, the app will crash when trying to load pins, with exception text "Unknown GPIO chip gpiochip4".