### PR TITLE
Add enum definitions for Bluetooth events and updated some comments.

### DIFF
--- a/Source/implementations/f7/Meadow.F7/Devices/Esp32Coprocessor/SharedEnums.cs
+++ b/Source/implementations/f7/Meadow.F7/Devices/Esp32Coprocessor/SharedEnums.cs
@@ -544,25 +544,49 @@ internal enum WiFiFunction
 public enum BluetoothFunction
 {
     /// <summary>
-    /// BluetoothFunction - Start
+    /// Start the Bluetooth service.
     /// </summary>
     Start = 0,
     /// <summary>
-    /// BluetoothFunction - Stop
+    /// Stop the Bluetooth service.
     /// </summary>
     Stop = 1,
     /// <summary>
-    /// BluetoothFunction - GetHandles
+    /// Get the handles for the service and characteristics.
     /// </summary>
     GetHandles = 2,
     /// <summary>
-    /// BluetoothFunction - ServerDataSet
+    /// BSet a characteristic value.
     /// </summary>
     ServerDataSet = 3,
     /// <summary>
-    /// BluetoothFunction - ClientWriteRequestEvent
+    /// Client has written to a characteristic value.
     /// </summary>
-    ClientWriteRequestEvent = 4
+    ClientWriteRequestEvent = 4,
+    /// <summary>
+    /// Bluetooth service is starting event.
+    /// </summary>
+    BluetoothStartingEvent = 5,
+    /// <summary>
+    /// Bluetooth has started event.
+    /// </summary>
+    BluetoothStartedEvent = 6,
+    /// <summary>
+    /// Bluetooth is stopping event.
+    /// </summary>
+    BluetoothStoppingEvent = 7,
+    /// <summary>
+    /// Bluetooth has stopped event.
+    /// </summary>
+    BluetoothStoppedEvent = 8,
+    /// <summary>
+    /// Bluetooth client connected event.
+    /// </summary>
+    ClientConnectedEvent = 9,
+    /// <summary>
+    /// Bluetooth client disconnected event.
+    /// </summary>
+    ClientDisconnectedEvent = 10,
 };
 
 /// <summary>


### PR DESCRIPTION
Added some enums for consistency across the three platfoms.

Events will be raised in a future ESP PR.