### PR TITLE
add limit check to health.cpu_temp_celsius

### DIFF
--- a/Source/Meadow.Core/Cloud/HealthReporter.cs
+++ b/Source/Meadow.Core/Cloud/HealthReporter.cs
@@ -76,7 +76,11 @@ public class HealthReporter : IHealthReporter
 
     private (string name, Func<object?> function)[] DefaultMetrics =
     {
-        new ("health.cpu_temp_celsius", () => Resolver.Device.PlatformOS.GetCpuTemperature().Celsius),
+        new ("health.cpu_temp_celsius", () =>
+        {
+            var temp = Resolver.Device.PlatformOS.GetCpuTemperature().Celsius;
+            return temp < -30 ? -30 : temp > 70 ? 70 : temp;
+        }),
         new ("health.memory_used", () => GC.GetTotalMemory(false)),
         new ("health.disk_space_used", () => Resolver.Device.PlatformOS.GetPrimaryDiskSpaceInUse().Bytes),
         new ("info.os_version", () => Resolver.Device.Information.OSVersion),


### PR DESCRIPTION
Limit reported health.cpu_temp_celsius to +/-10C of operational limits of Meadow F7.

This masks errors in the underpinning measurement system that occasionally reports excessively high cpu temp.