### PR TITLE
Synchronise shared enums across managed/stm/esp code bases.

### DIFF
--- a/Source/implementations/f7/Meadow.F7/Devices/Esp32Coprocessor/SharedEnums.cs
+++ b/Source/implementations/f7/Meadow.F7/Devices/Esp32Coprocessor/SharedEnums.cs
@@ -793,7 +793,15 @@ public enum ConfigurationItems
     /// <summary>
     /// ConfigurationItems - SoftApMacAddress
     /// </summary>
-    SoftApMacAddress = 14
+    SoftApMacAddress = 14,
+    /// <summary>
+    /// ConfigurationItems - SubnetMask
+    /// </summary>
+    SubnetMask = 15,
+    /// <summary>
+    /// ConfigurationItems - BluetoothMacAddress
+    /// </summary>
+    BluetoothMacAddress = 16,
 };
 
 /// <summary>


### PR DESCRIPTION
Trivial change to keep the shared enums in sync.