### PR TITLE
Set persistent connections on MQTT client side

### DIFF
--- a/Source/Meadow.Core/Cloud/MeadowCloudConnectionService.cs
+++ b/Source/Meadow.Core/Cloud/MeadowCloudConnectionService.cs
@@ -348,6 +348,8 @@ internal class MeadowCloudConnectionService : IMeadowCloudService
                                 tlsParameters.UseTls = Settings.MqttPort == 8883;
                             })
                             .WithProtocolVersion(MQTTnet.Formatter.MqttProtocolVersion.V500)
+                            .WithCleanSession(false)
+                            .WithSessionExpiryInterval(86400) // Keep the session for 1 day
                             .WithCommunicationTimeout(TimeSpan.FromSeconds(30));
 
                         if (Settings.UseAuthentication)


### PR DESCRIPTION
Set `clean session` to `false` and configure a session `expiry interval` of 24 hours (3600 * 24 seconds). This ensures that MQTT commands sent while the device is offline will be delivered once it reconnects. ([#809](https://github.com/WildernessLabs/Meadow_Issues/issues/809)) 