### PR TITLE
Fix WiFi Event

### DIFF
--- a/Source/implementations/f7/Meadow.F7/Devices/Esp32Coprocessor/Esp32WiFiAdapter.cs
+++ b/Source/implementations/f7/Meadow.F7/Devices/Esp32Coprocessor/Esp32WiFiAdapter.cs
@@ -262,6 +262,7 @@ internal class Esp32WiFiAdapter : NetworkAdapterBase, IWiFiNetworkAdapter
 
                 break;
             case WiFiFunction.ConnectionRetryCountExceeded:
+                break;
             case WiFiFunction.NetworkDisconnectedEvent:
                 RaiseWiFiDisconnected(statusCode, payload);
                 CurrentState = NetworkState.Disconnected;


### PR DESCRIPTION
## Summary 
The PR aims to add a minor change to the switch statement in WiFi events. The **ConnectionRetryCountExceeded** always occurs before the **NetworkDisconnectedEvent** .