### PR TITLE
[OTA] Cleanup update store on startup, and delete MPAK on extraction.

### DIFF
--- a/Source/Meadow.Core/Cloud/MeadowCloudUpdateService.cs
+++ b/Source/Meadow.Core/Cloud/MeadowCloudUpdateService.cs
@@ -381,7 +381,14 @@ internal class MeadowCloudUpdateService : IUpdateService
         }
         finally
         {
-            File.Delete(sourcePath!);
+            try
+            {
+                File.Delete(sourcePath!);
+            }
+            catch (Exception ex)
+            {
+                Resolver.Log.Error($"Failed to delete source file: {ex.Message}");
+            }
         }
 
         // do we actually contain an update?

--- a/Source/Meadow.Core/Cloud/MeadowCloudUpdateService.cs
+++ b/Source/Meadow.Core/Cloud/MeadowCloudUpdateService.cs
@@ -158,6 +158,7 @@ internal class MeadowCloudUpdateService : IUpdateService
     /// </summary>
     public void Start()
     {
+        CleanupUpdateStore();
         _isEnabled = true;
     }
 
@@ -342,7 +343,7 @@ internal class MeadowCloudUpdateService : IUpdateService
 
         Resolver.Log.Debug($"Applying update from '{sourcePath}'");
 
-        if (sourcePath == null)
+        if (sourcePath == null || !File.Exists(sourcePath))
         {
             UpdateFailure?.Invoke(this, updateInfo);
             throw new ArgumentException($"Cannot find update with ID {updateInfo.ID}");
@@ -377,6 +378,10 @@ internal class MeadowCloudUpdateService : IUpdateService
             Resolver.Log.Error($"Failed to extract update package: {ex.Message}");
             UpdateFailure?.Invoke(this, updateInfo);
             throw ex;
+        }
+        finally
+        {
+            File.Delete(sourcePath!);
         }
 
         // do we actually contain an update?
@@ -432,6 +437,23 @@ internal class MeadowCloudUpdateService : IUpdateService
             {
                 d.Delete();
             }
+        }
+    }
+
+    private void CleanupUpdateStore()
+    {
+        try
+        {
+            var di = new DirectoryInfo(UpdateStoreDirectory);
+            if (di.Exists)
+            {
+                Resolver.Log.Debug($"Cleaning up extracted update files in {UpdateStoreDirectory}");
+                DeleteDirectoryContents(di);
+            }
+        }
+        catch (Exception ex)
+        {
+            Resolver.Log.Error($"Error cleaning up update directory: {ex.Message}");
         }
     }
 


### PR DESCRIPTION
We clean on startup to not leak storage in case of catastrophic OS/power failures during updates.

We also ensure that the device reboots and applies the update with free space available, by deleting the MPAK immediately after extraction.