### PR TITLE
Delete rollback directory after a successful App.Initialize() call

### DIFF
--- a/Source/Meadow.Core/Cloud/MeadowCloudUpdateService.cs
+++ b/Source/Meadow.Core/Cloud/MeadowCloudUpdateService.cs
@@ -357,7 +357,7 @@ internal class MeadowCloudUpdateService : IUpdateService
         }
         else
         {
-            DeleteDirectoryContents(di);
+            MeadowOS.DeleteDirectoryContents(di);
         }
 
         try
@@ -430,23 +430,6 @@ internal class MeadowCloudUpdateService : IUpdateService
         State = _connectionService.ConnectionState == CloudConnectionState.Connected ? UpdateState.Connected : UpdateState.Disconnected;
     }
 
-    private void DeleteDirectoryContents(DirectoryInfo di, bool deleteDirectory = false)
-    {
-        foreach (var f in di.EnumerateFiles())
-        {
-            f.Delete();
-        }
-
-        foreach (var d in di.EnumerateDirectories())
-        {
-            DeleteDirectoryContents(d, true);
-            if (deleteDirectory)
-            {
-                d.Delete();
-            }
-        }
-    }
-
     private void CleanupUpdateStore()
     {
         try
@@ -455,7 +438,7 @@ internal class MeadowCloudUpdateService : IUpdateService
             if (di.Exists)
             {
                 Resolver.Log.Debug($"Cleaning up extracted update files in {UpdateStoreDirectory}");
-                DeleteDirectoryContents(di);
+                MeadowOS.DeleteDirectoryContents(di);
             }
         }
         catch (Exception ex)

--- a/Source/Meadow.Core/MeadowOS.cs
+++ b/Source/Meadow.Core/MeadowOS.cs
@@ -130,6 +130,11 @@ public static partial class MeadowOS
                 Resolver.Log.Trace("Initializing App", MessageGroup.Core);
                 await App.Initialize();
 
+                // if system and app are initialized without faults, we can finally remove the rollback directory
+                var rollback_dir = new DirectoryInfo("/meadow0/rollback");
+                DeleteDirectoryContents(rollback_dir, deleteDirectory: true);
+
+
                 stepName = "App Run";
 
                 Resolver.Log.Trace("Running App", MessageGroup.Core);
@@ -941,6 +946,26 @@ public static partial class MeadowOS
 
         // final shutdown - which really is just an infinite Sleep()
         Shutdown();
+    }
+
+    /// <summary>
+    /// Utility method to delete non-empty directories
+    /// </summary>
+    public static void DeleteDirectoryContents(DirectoryInfo di, bool deleteDirectory = false)
+    {
+        foreach (var f in di.EnumerateFiles())
+        {
+            f.Delete();
+        }
+
+        foreach (var d in di.EnumerateDirectories())
+        {
+            DeleteDirectoryContents(d, true);
+            if (deleteDirectory)
+            {
+                d.Delete();
+            }
+        }
     }
 }
 


### PR DESCRIPTION
We now define in implementation this point (post-App.Initialize(), pre-App.Run() as the point of no return for executing an update rollback