### PR TITLE
Rework MeadowCloudUpdateService/UpdateStore for OTA hardening + Enable reliable messaging for OTA

### DIFF
--- a/Source/Meadow.Core/Cloud/MeadowCloudConnectionService.cs
+++ b/Source/Meadow.Core/Cloud/MeadowCloudConnectionService.cs
@@ -2,6 +2,7 @@
 using Meadow.Hardware;
 using Meadow.Update;
 using MQTTnet;
+using MQTTnet.Adapter;
 using MQTTnet.Client;
 using MQTTnet.Client.Connecting;
 using MQTTnet.Client.Disconnecting;

--- a/Source/Meadow.Core/Cloud/MeadowCloudConnectionService.cs
+++ b/Source/Meadow.Core/Cloud/MeadowCloudConnectionService.cs
@@ -342,8 +342,10 @@ internal class MeadowCloudConnectionService : IMeadowCloudService
                 case CloudConnectionState.Connecting:
                     if (ClientOptions == null)
                     {
-                        Resolver.Log.Debug("Creating MQTT client options", "cloud");
+                        var client_id = Resolver.Device?.Information.UniqueID.ToUpper();
+                        Resolver.Log.Debug($"Creating MQTT client ID {client_id}", "cloud");
                         var builder = new MqttClientOptionsBuilder()
+                            .WithClientId(client_id)
                             .WithTcpServer(Settings.MqttHostname, Settings.MqttPort)
                             .WithTls(tlsParameters =>
                             {
@@ -438,7 +440,10 @@ internal class MeadowCloudConnectionService : IMeadowCloudService
                             }
 
                             Resolver.Log.Debug($"Meadow.Cloud service subscribing to '{topicName}'", "cloud");
-                            await MqttClient.SubscribeAsync(new MqttTopicFilterBuilder().WithTopic(topicName).Build());
+                            await MqttClient.SubscribeAsync(new MqttTopicFilterBuilder()
+                                                                .WithTopic(topicName)
+                                                                .WithQualityOfServiceLevel(MQTTnet.Protocol.MqttQualityOfServiceLevel.AtLeastOnce)
+                                                                .Build());
                         }
                         ConnectionState = CloudConnectionState.Connected;
                     }

--- a/Source/Meadow.Core/Cloud/MeadowCloudUpdateService.cs
+++ b/Source/Meadow.Core/Cloud/MeadowCloudUpdateService.cs
@@ -363,9 +363,8 @@ internal class MeadowCloudUpdateService : IUpdateService
         try
         {
             // extract zip
-            Resolver.Log.Debug($"Extracting update to '{UpdateDirectory}'...");
             var sw = Stopwatch.StartNew();
-            ZipFile.ExtractToDirectory(sourcePath, UpdateDirectory);
+            MeadowOS.SafelyExtractZIPFile(sourcePath, UpdateDirectory);
             sw.Stop();
             Resolver.Log.Debug($"Extracting took {sw.Elapsed.TotalSeconds} seconds.");
 

--- a/Source/Meadow.Core/Cloud/MeadowCloudUpdateService.cs
+++ b/Source/Meadow.Core/Cloud/MeadowCloudUpdateService.cs
@@ -68,7 +68,7 @@ internal class MeadowCloudUpdateService : IUpdateService
                 continue;
 
             
-            var service_or_update_cancellation = CancellationTokenSource.CreateLinkedTokenSource(_service_cancellation.Token,
+            using var service_or_update_cancellation = CancellationTokenSource.CreateLinkedTokenSource(_service_cancellation.Token,
                                                                                                      update_cancellation.Token);
 
             try
@@ -222,7 +222,8 @@ internal class MeadowCloudUpdateService : IUpdateService
             Log.Debug($"Resuming from offset {fileStream.Length}", "update service");
             request.Headers.Range = new System.Net.Http.Headers.RangeHeaderValue(fileStream.Length, null);
 
-            var response = await httpClient.SendAsync(request, HttpCompletionOption.ResponseHeadersRead, new CancellationTokenSource(millisecondsDelay: 15000).Token);
+            using var sendCts = new CancellationTokenSource(millisecondsDelay: 15000);
+            var response = await httpClient.SendAsync(request, HttpCompletionOption.ResponseHeadersRead, sendCts.Token);
             var contentLength = response.Content.Headers.ContentLength;
             if (contentLength.HasValue)
             {

--- a/Source/Meadow.Core/Cloud/MeadowCloudUpdateService.cs
+++ b/Source/Meadow.Core/Cloud/MeadowCloudUpdateService.cs
@@ -3,19 +3,16 @@ using MQTTnet;
 using System;
 using System.Diagnostics;
 using System.IO;
-using System.IO.Compression;
-using System.Linq;
 using System.Net.Http;
+using System.Threading;
 using System.Threading.Tasks;
 
 namespace Meadow;
 
+using static Resolver;
+
 internal class MeadowCloudUpdateService : IUpdateService
 {
-    private const string PackageDirectoryOs = "os";
-    private const string PackageDirectoryApp = "app";
-    private const string PackageDirectoryFirmware = "firmware";
-
     public event EventHandler<UpdateState>? StateChanged;
     /// <inheritdoc/>
     public event UpdateEventHandler? UpdateAvailable;
@@ -28,114 +25,129 @@ internal class MeadowCloudUpdateService : IUpdateService
     /// <inheritdoc/>
     public event UpdateEventHandler? UpdateFailure;
 
-    /// <summary>
-    /// Specifies the maximum number of download attempts before giving up.
-    /// </summary>
-    public const int MaxDownloadRetries = 10;
-    /// <summary>
-    /// Retry period the service will use to attempt network reconnection
-    /// </summary>
-    private const int NetworkRetryTimeoutSeconds = 15;
-    /// <summary>
-    /// Period the service will wait between download attempts in 
-    /// case of failure.
-    /// </summary>
-    public const int RetryDelayMilliseconds = 1000;
+    const int RetryDelayMilliseconds = 1000;
+    const int UpdateServicePulseMilliseconds = 10000;
+
+    readonly byte[] read_buffer = new byte[1024 * 384]; // TODO: make this configurable/platform dependent
+    readonly byte[] write_buffer = new byte[1024 * 384]; // TODO: make this configurable/platform dependent
 
     private const string DefaultUpdateStoreDirectoryName = "update-store";
     private const string DefaultUpdateDirectoryName = "update";
 
     private readonly MeadowCloudConnectionService _connectionService;
-    private UpdateState _state;
-    private bool _downloadInProgress;
+    private UpdateState _state = UpdateState.Disconnected;
 
     private UpdateStore Store { get; }
     private string UpdateDirectory { get; }
     private string UpdateStoreDirectory { get; }
 
+    private CancellationTokenSource _service_cancellation = new();
+    CancellationTokenSource update_cancellation = new();
+    public Task UpdateServiceTask = Task.CompletedTask;
+
     public MeadowCloudUpdateService(string fsRoot, MeadowCloudConnectionService connectionService)
     {
         UpdateStoreDirectory = Path.Combine(fsRoot, DefaultUpdateStoreDirectoryName);
         UpdateDirectory = Path.Combine(fsRoot, DefaultUpdateDirectoryName);
-
         Store = new UpdateStore(UpdateStoreDirectory);
 
         _connectionService = connectionService;
         _connectionService.MqttMessageReceived += OnMqttMessageReceived;
-        _connectionService.AddSubscription("{OID}/ota/{ID}");
-        _connectionService.ConnectionStateChanged += OnConnectionStateChanged;
+        _connectionService.AddSubscription("{OID}/ota/{ID}");   
     }
 
-    private void OnConnectionStateChanged(object sender, CloudConnectionState e)
-    {
-        switch (e)
+    private async Task UpdateService()
+    {        
+        while (true)
         {
-            case CloudConnectionState.Unknown:
-            case CloudConnectionState.Disconnected:
-            case CloudConnectionState.Authenticating:
-            case CloudConnectionState.Connecting:
-            case CloudConnectionState.Subscribing:
-                if (State != UpdateState.UpdateInProgress)
+            await Task.Delay(UpdateServicePulseMilliseconds);
+            Log.Trace($"store state: {Store.State} cloud connection state: {_connectionService.ConnectionState}", "update service");
+
+            _service_cancellation.Token.ThrowIfCancellationRequested();
+            if (_connectionService.ConnectionState != CloudConnectionState.Connected && Store.State != UpdateStore.States.Mpak)
+                continue;
+
+            
+            var service_or_update_cancellation = CancellationTokenSource.CreateLinkedTokenSource(_service_cancellation.Token,
+                                                                                                     update_cancellation.Token);
+
+            try
+            {
+                switch (Store.State)
                 {
-                    State = UpdateState.Disconnected;
+
+                    case UpdateStore.States.Empty:
+                        //nothing - wait for OnMqttMessageReceived
+                        break;
+                    case UpdateStore.States.Manifest:
+                        Log.Debug("update available", "update service");
+                        UpdateAvailable?.Invoke(this, Store.Manifest!, update_cancellation);
+                        update_cancellation.Token.ThrowIfCancellationRequested();
+                        await DownloadProc(Store.Manifest!, service_or_update_cancellation);
+                        Store.CompleteMpak();
+
+                        break;
+                    case UpdateStore.States.Mpak:
+                        Log.Debug("update retrieved", "update service");
+                        UpdateRetrieved?.Invoke(this, Store.Manifest!, update_cancellation);
+                        update_cancellation.Token.ThrowIfCancellationRequested();
+                        ApplyUpdate(Store.Manifest!);
+                        Store.State = UpdateStore.States.Empty;                       
+                        Log.Debug($"Requesting a device reset to apply the Update");
+                        Device.PlatformOS.Reset();
+                        UpdateSuccess?.Invoke(this, Store.Manifest!, update_cancellation); // not called - device has reset by now
+                        break;
                 }
-                break;
-            case CloudConnectionState.Connected:
-                if (_downloadInProgress)
+            }
+            catch (OperationCanceledException e)
+            {
+                if (e.CancellationToken == update_cancellation.Token)
                 {
-                    State = UpdateState.DownloadingFile;
+                    Log.Info("Update cancellation detected, clearing update store", "update service");
+                    Store.State = UpdateStore.States.Empty;
+                    update_cancellation.Dispose();
+                    update_cancellation = new();
                 }
-                else if (State != UpdateState.UpdateInProgress)
-                {
-                    State = UpdateState.Connected;
-                }
-                break;
+            }
+            catch (Exception e)
+            {
+                Log.Error(e, "update service");
+                UpdateFailure?.Invoke(this, Store.Manifest!, update_cancellation);
+            }
         }
     }
 
     private void OnMqttMessageReceived(object sender, MqttApplicationMessage e)
     {
-        if (e.Topic.EndsWith($"/ota/{Resolver.Device.Information.UniqueID}", StringComparison.OrdinalIgnoreCase))
+        Log.Debug("MQTT message received", "update service");
+        if (!e.Topic.EndsWith($"/ota/{Device.Information.UniqueID}", StringComparison.OrdinalIgnoreCase))
+            return;
+
+        Log.Debug("MQTT message is OTA message for this device", "update service");
+
+        try
         {
-            if (!_isEnabled)
+            var temp_path = Path.Combine(
+                MeadowOS.FileSystem.TempDirectory,
+                $"manifest_{Guid.NewGuid():N}"); // TODO: Replace with Path.GetTempPath() when https://github.com/WildernessLabs/Meadow/pull/734 lands
+            Log.Debug($"Using temp path {temp_path}");
+            File.WriteAllBytes(temp_path, e.Payload);
+
+            if (Store.State != UpdateStore.States.Empty)
             {
-                Resolver.Log.Warn("Meadow update message received, but updates are currently disabled", "cloud");
-                return;
+                // cancel old update
+                var current_update_cancellation = update_cancellation;
+                current_update_cancellation.Cancel();
+                while (current_update_cancellation == update_cancellation)
+                    Thread.Sleep(1000);
+                Store.State = UpdateStore.States.Empty; // should not be needed
             }
-
-            Resolver.Log.Info("Meadow update message received", "cloud");
-
-            var info = Resolver.JsonSerializer.Deserialize<UpdateMessage>(e.Payload);
-
-            if (info == null)
-            {
-                Resolver.Log.Warn($"Unable to deserialize Updater Message");
-            }
-            else
-            {
-                Resolver.Log.Trace($"Updater Message Received: {info.ID}");
-
-                // do we already know about this update?
-                if (Store.TryGetMessage(info.ID, out UpdateMessage? msg))
-                {
-                    if (!(msg?.Retrieved ?? false))
-                    {
-                        Resolver.Log.Trace($"Update {info.ID} is known but not retrieved");
-
-                        UpdateAvailable?.Invoke(this, info);
-                    }
-                    else
-                    {
-                        Resolver.Log.Trace($"Update {info.ID} has already been retrieved");
-                    }
-                }
-                else
-                {
-                    Store.Add(info);
-                    UpdateAvailable?.Invoke(this, info);
-                }
-
-            }
+            //Store.AddManifest(temp_path);
+            File.Copy(temp_path, "/meadow0/update-store/info.json");
+        }
+        catch (Exception ex)
+        {
+            Log.Error(ex, "update service");
         }
     }
 
@@ -151,60 +163,148 @@ internal class MeadowCloudUpdateService : IUpdateService
         }
     }
 
-    private bool _isEnabled = false;
-
     /// <summary>
     /// Starts the service if it is not already running
     /// </summary>
     public void Start()
     {
-        CleanupUpdateStore();
-        _isEnabled = true;
+        // _connectionService.MqttMessageReceived += OnMqttMessageReceived;
+        UpdateServiceTask = Task.Run(async () =>
+        {
+            try
+            {
+                await UpdateService();
+            }
+            catch (Exception e)
+            {
+                Log.Error(e, "updater service");
+                Stop();
+            }
+        }, _service_cancellation.Token);
+        State = UpdateState.Connected;
+        Log.Info("Update Service started", "update service");
     }
 
     /// <inheritdoc/>
     public void Stop()
     {
-        _isEnabled = false;
+        // _connectionService.MqttMessageReceived -= OnMqttMessageReceived;
+        _service_cancellation.Cancel();
+        _service_cancellation.Dispose();
+        _service_cancellation = new();
+        State = UpdateState.Disconnected;
+        Log.Info("Update Service stopped", "update service");
     }
 
-    /// <inheritdoc/>
-    public void ClearUpdates()
+    private async Task SafeDownloadFile(string url, UpdateInfo message, CancellationTokenSource cancel)
     {
-        Store.Clear();
-    }
+        Log.Debug($"Attempting to retrieve {url}");
+        var sw = Stopwatch.StartNew();
 
-    /// <inheritdoc/>
-    public void RetrieveUpdate(UpdateInfo updateInfo)
-    {
-        State = UpdateState.DownloadingFile;
+        long totalBytesDownloaded = 0;
 
-        UpdateMessage? message;
-
-
-        if (!Store.TryGetMessage(updateInfo.ID, out message))
+        try
         {
-            throw new ArgumentException($"Cannot find update with ID {updateInfo.ID}");
+            // Add timeout settings to HttpClient
+            using var httpClient = new HttpClient();
+
+            // Set timeout for the entire operation
+            httpClient.Timeout = TimeSpan.FromMinutes(20); // 20 min should download 10MB at 10KB/sec - and we can always resume
+
+            using var request = new HttpRequestMessage(HttpMethod.Get, url);
+            if (_connectionService.Settings.UseAuthentication)
+            {
+                request.Headers.Authorization = _connectionService.CreateAuthenticationHeaderValue();
+            }
+
+            // Configure the HTTP range header to indicate resumption of partial download, starting from 
+            // the 'EOF' byte position of the partial download and extending to the end of the content.
+            using var fileStream = Store.StartMpak();
+            Log.Debug($"Resuming from offset {fileStream.Length}");
+            request.Headers.Range = new System.Net.Http.Headers.RangeHeaderValue(fileStream.Length, null);
+
+            // Create a cancellation token with timeout to prevent stalled downloads
+            using var downloadCts = new CancellationTokenSource();
+            var response = await httpClient.SendAsync(request, HttpCompletionOption.ResponseHeadersRead, downloadCts.Token);
+            var contentLength = response.Content.Headers.ContentLength;
+            if (contentLength.HasValue)
+            {
+                // Content-Length indicates the remaining bytes to download, as the Range header may change after retries.
+                // Then, to determine the total file size, the Content-Length from the first download attempt is used.
+                if (message.FileSize == 0)
+                    message.FileSize = contentLength.Value;
+                Log.Debug($"File size: {message.FileSize:N0} bytes.");
+            }
+
+            using var stream = await response.Content.ReadAsStreamAsync();
+            int bytesRead;
+
+            // Add a timer to detect stalled downloads
+            var lastProgressTime = DateTime.UtcNow;
+            using var progressTimer = new Timer(_ =>
+            {
+                Log.Trace($"{DateTime.UtcNow - lastProgressTime} since last chunk downloaded", "update service");
+                if ((DateTime.UtcNow - lastProgressTime) > TimeSpan.FromMinutes(1))
+                {
+                    Log.Warn("Stall detected, cancelling download", "update service");
+                    downloadCts.Cancel();
+                }
+            }, null, 30000, 30000);
+
+            Task writeTask = Task.CompletedTask;
+            while ((bytesRead = await stream.ReadAsync(read_buffer, 0, read_buffer.Length, downloadCts.Token)) > 0)
+            {
+                await writeTask; // wait for last write to disk task to complete
+                Buffer.BlockCopy(read_buffer, 0, write_buffer, 0, bytesRead);
+
+                writeTask = fileStream.WriteAsync(write_buffer, 0, bytesRead, downloadCts.Token);
+
+                totalBytesDownloaded += bytesRead;
+
+                // Update progress tracking timestamp
+                lastProgressTime = DateTime.UtcNow;
+
+                message.DownloadProgress = totalBytesDownloaded;
+
+                RetrieveProgress?.Invoke(this, message, update_cancellation);
+                update_cancellation.Token.ThrowIfCancellationRequested();
+                cancel.Token.ThrowIfCancellationRequested();
+
+                Log.Trace($"Download progress: {totalBytesDownloaded:N0} bytes downloaded");
+            }
+            await writeTask; // wait for last write to disk task to complete
+
+            sw.Stop();
+            Log.Debug($"Download complete: {totalBytesDownloaded} bytes in {sw.Elapsed.TotalSeconds} secs.");
         }
 
-        if (message != null)
+        catch (OperationCanceledException)
         {
-            Task.Run(() => DownloadProc(message))
-                .RethrowUnhandledExceptions();
+            sw.Stop();
+            Log.Error($"Download timed out or cancelled after {sw.Elapsed.TotalSeconds:0} seconds", "update service");
+            await Task.Delay(RetryDelayMilliseconds);
+            throw;
+        }
+        catch (Exception ex)
+        {
+            sw.Stop();
+            Log.Error($"[ {ex.GetType().Name} ] Failed to download Update after {sw.Elapsed.TotalSeconds:0} seconds: {ex.Message} {ex.StackTrace}", "update service");
+            await Task.Delay(RetryDelayMilliseconds);
+            throw;
         }
     }
 
-    private async Task DownloadProc(UpdateMessage message)
+    private async Task DownloadProc(UpdateMessage message, CancellationTokenSource cancel)
     {
-        Resolver.Log.Trace($"Device OS Version: {Resolver.Device.PlatformOS.OSVersion}, Update OS Version: {message.OsVersion}");
+        Log.Debug($"Device OS Version: {Resolver.Device.PlatformOS.OSVersion}, Update OS Version: {message.OsVersion}");
 
         var destination = message.MpakDownloadUrl;
 
         if (!string.IsNullOrEmpty(message.OsVersion)
-            && Resolver.Device.PlatformOS.OSVersion != message.OsVersion)
+            && Device.PlatformOS.OSVersion != message.OsVersion)
         {
-            Resolver.Log.Trace($"This OTA requires an OS update.");
-            destination = message.MpakWithOsDownloadUrl;
+            Log.Debug($"This OTA requires an OS update.");
+            // destination = message.MpakWithOsDownloadUrl; DISABLING UNTIL CRC CHECKS WORK
         }
 
         if (!destination.StartsWith("http"))
@@ -219,146 +319,16 @@ internal class MeadowCloudUpdateService : IUpdateService
             }
         }
 
-        Resolver.Log.Trace($"Attempting to retrieve {destination}");
-        var sw = Stopwatch.StartNew();
-
-        long totalBytesDownloaded = 0;
-        _downloadInProgress = true;
-
-        for (int retryCount = 0; retryCount < MaxDownloadRetries && _downloadInProgress; retryCount++)
-        {
-            try
-            {
-                // Note: this is infrequently called, so we don't want to follow the advice of "use one instance for all calls"
-                using (var httpClient = new HttpClient())
-                {
-                    using (var request = new HttpRequestMessage(HttpMethod.Get, destination))
-                    {
-                        if (_connectionService.Settings.UseAuthentication)
-                        {
-                            request.Headers.Authorization = _connectionService.CreateAuthenticationHeaderValue();
-                        }
-
-                        // Configure the HTTP range header to indicate resumption of partial download, starting from 
-                        // the 'totalBytesDownloaded' byte position and extending to the end of the content.
-                        request.Headers.Range = new System.Net.Http.Headers.RangeHeaderValue(totalBytesDownloaded, null);
-
-                        // Get the actual update file size, which might be larger than the expected
-                        // if this OTA requires an OS update
-                        var response = await httpClient.SendAsync(request, HttpCompletionOption.ResponseHeadersRead);
-                        var contentLength = response.Content.Headers.ContentLength;
-                        if (contentLength.HasValue && retryCount == 0)
-                        {
-                            // Content-Length indicates the remaining bytes to download, as the Range header may change after retries.
-                            // Then, to determine the total file size, the Content-Length from the first download attempt is used.
-                            message.FileSize = contentLength.Value;
-                            Resolver.Log.Trace($"Starting download... File size: {message.FileSize.ToString("N0")} bytes.");
-                        }
-
-                        using (var stream = await response.Content.ReadAsStreamAsync())
-                        {
-                            using (var fileStream = Store.GetUpdateFileStream(message.ID))
-                            {
-                                byte[] buffer = new byte[1024 * 64]; // TODO: make this configurable/platform dependent
-                                int bytesRead;
-
-                                while ((bytesRead = await stream.ReadAsync(buffer, 0, buffer.Length)) > 0)
-                                {
-                                    await fileStream.WriteAsync(buffer, 0, bytesRead);
-                                    totalBytesDownloaded += bytesRead;
-
-                                    message.DownloadProgress = totalBytesDownloaded;
-
-                                    RetrieveProgress?.Invoke(this, message);
-                                    Resolver.Log.Trace($"Download progress: {totalBytesDownloaded:N0} bytes downloaded");
-                                }
-                            }
-                        }
-                    }
-                }
-
-                sw.Stop();
-
-                var path = Store.GetUpdateArchivePath(message.ID);
-                var fi = new FileInfo(path);
-
-                if (sw.Elapsed.Seconds > 0)
-                {
-                    Resolver.Log.Info($"Retrieved {fi.Length} bytes in {sw.Elapsed.TotalSeconds:0} sec ({fi.Length / sw.Elapsed.Seconds:0} bps)");
-                }
-                else
-                {
-                    // don't divide by 0
-                    Resolver.Log.Info($"Retrieved {fi.Length} bytes in {sw.Elapsed.TotalSeconds:0} sec");
-                }
-
-                _downloadInProgress = false;
-
-                var hash = await Store.GetFileHash(fi);
-
-                if (!string.IsNullOrWhiteSpace(message.Crc))
-                {
-                    if (hash != message.Crc)
-                    {
-                        Resolver.Log.Warn("Downloaded Hash does not match expected Hash");
-                        // TODO: what do we do? Retry? Ignore?
-                    }
-                    else
-                    {
-                        Resolver.Log.Trace("Update package hash matched");
-                    }
-                }
-                else
-                {
-                    Resolver.Log.Warn("Downloaded Updated was not Hashed by server!");
-                    // TODO: what do we do?
-                }
-
-                UpdateRetrieved?.Invoke(this, message);
-                Store.SetRetrieved(message);
-            }
-            catch (Exception ex)
-            {
-                sw.Stop();
-
-                // TODO: raise some event?
-                Resolver.Log.Error($"[ {ex.GetType().Name} ] Failed to download Update after {sw.Elapsed.TotalSeconds:0} seconds: {ex.Message} {ex.StackTrace}");
-
-                Resolver.Log.Info($"Retrying attempt {retryCount + 1} of {MaxDownloadRetries} in {RetryDelayMilliseconds} milliseconds...");
-                await Task.Delay(RetryDelayMilliseconds);
-            }
-        }
+        await SafeDownloadFile(destination, message, cancel);
 
         State = _connectionService.ConnectionState == CloudConnectionState.Connected ? UpdateState.Connected : UpdateState.Disconnected;
-
-        _downloadInProgress = false;
     }
 
     /// <inheritdoc/>
-    public void ApplyUpdate(UpdateInfo updateInfo)
+    private void ApplyUpdate(UpdateInfo updateInfo)
     {
-        State = UpdateState.UpdateInProgress;
-
-        var sourcePath = Store.GetUpdateArchivePath(updateInfo.ID);
-
-        Resolver.Log.Debug($"Applying update from '{sourcePath}'");
-
-        if (sourcePath == null || !File.Exists(sourcePath))
-        {
-            UpdateFailure?.Invoke(this, updateInfo);
-            throw new ArgumentException($"Cannot find update with ID {updateInfo.ID}");
-        }
-
-        // ensure the update directory is currently empty
-        var di = new DirectoryInfo(UpdateDirectory);
-        if (!di.Exists)
-        {
-            di.Create();
-        }
-        else
-        {
-            MeadowOS.DeleteDirectoryContents(di);
-        }
+        var sourcePath = Store.MpakPath;
+        Log.Debug($"Applying update from '{sourcePath}'");
 
         try
         {
@@ -366,16 +336,15 @@ internal class MeadowCloudUpdateService : IUpdateService
             var sw = Stopwatch.StartNew();
             MeadowOS.SafelyExtractZIPFile(sourcePath, UpdateDirectory);
             sw.Stop();
-            Resolver.Log.Debug($"Extracting took {sw.Elapsed.TotalSeconds} seconds.");
+            Log.Debug($"Extracting took {sw.Elapsed.TotalSeconds} seconds.");
 
-            Resolver.Log.Debug($"Contents of Update");
-            Resolver.Log.Debug($"------------------");
+            Log.Debug($"Contents of Update");
+            Log.Debug($"------------------");
             DisplayTree(new DirectoryInfo(UpdateDirectory));
         }
         catch (Exception ex)
         {
-            Resolver.Log.Error($"Failed to extract update package: {ex.Message}");
-            UpdateFailure?.Invoke(this, updateInfo);
+            Log.Error($"Failed to extract update package: {ex.Message}");
             throw ex;
         }
         finally
@@ -386,102 +355,18 @@ internal class MeadowCloudUpdateService : IUpdateService
             }
             catch (Exception ex)
             {
-                Resolver.Log.Error($"Failed to delete source file: {ex.Message}");
+                Log.Error($"Failed to delete source file: {ex.Message}");
             }
         }
-
-        // do we actually contain an update?
-        var updateValid = CurrentUpdateContainsAppUpdate() || CurrentUpdateContainsOSUpdate();
-
-        // TODO: should we verify paths, etc?
-
-        if (!updateValid)
-        {
-            Resolver.Log.Warn($"Update {updateInfo.ID} contains no valid Update data");
-            UpdateFailure?.Invoke(this, updateInfo);
-
-            // TODO: should we delete the update or quarantine it?
-
-            return;
-        }
-
-        // shut down the app (or timeout)
-        Resolver.Log.Debug($"Stopping application to allow update");
-        var shutdownTimeoutTask = Task.Delay(TimeSpan.FromSeconds(5));
-        var shutDownTask = Resolver.App?.OnShutdown();
-
-        // cancel the app run cancellation token
-        MeadowOS.AppAbort.Cancel();
-
-        // wait for the app to return, or the timeout
-        Task.WaitAny(shutDownTask, shutdownTimeoutTask);
-
-        // restart the device
-        Resolver.Log.Debug($"Requesting a device reset to apply the Update");
-        Resolver.Device.PlatformOS.Reset();
-
-        // the OS will handle updates on the next boot
-
-        // TODO: these will never happen due to the above reset. need to be moved to "post update boot"
-        Store.SetApplied(updateInfo);
-        UpdateSuccess?.Invoke(this, updateInfo);
-
-        State = _connectionService.ConnectionState == CloudConnectionState.Connected ? UpdateState.Connected : UpdateState.Disconnected;
-    }
-
-    private void CleanupUpdateStore()
-    {
-        try
-        {
-            var di = new DirectoryInfo(UpdateStoreDirectory);
-            if (di.Exists)
-            {
-                Resolver.Log.Debug($"Cleaning up extracted update files in {UpdateStoreDirectory}");
-                MeadowOS.DeleteDirectoryContents(di);
-            }
-        }
-        catch (Exception ex)
-        {
-            Resolver.Log.Error($"Error cleaning up update directory: {ex.Message}");
-        }
-    }
-
-    private bool CurrentUpdateContainsAppUpdate()
-    {
-        var di = new DirectoryInfo(UpdateDirectory);
-        var appDir = di.GetDirectories(PackageDirectoryApp).FirstOrDefault();
-        if (appDir == null)
-        {
-            return false;
-        }
-
-        // make sure that some files exist - no files would brick us.  A bad set still can
-        return appDir.GetFiles().Count() > 0;
-    }
-
-    private bool CurrentUpdateContainsOSUpdate()
-    {
-        var di = new DirectoryInfo(UpdateDirectory);
-        var osDir = di.GetDirectories(PackageDirectoryOs).FirstOrDefault();
-        var firmwareDir = di.GetDirectories(PackageDirectoryFirmware).FirstOrDefault();
-        if (osDir == null && firmwareDir == null)
-        {
-            return false;
-        }
-
-        // make sure that some files exist
-        return osDir?.GetFiles().Count() > 0 || firmwareDir?.GetFiles().Count() > 0;
     }
 
     private void DisplayTree(DirectoryInfo di)
     {
-        Resolver.Log.Debug($"+ {di.Name}");
-
+        Log.Debug($"+ {di.Name}");
         foreach (var f in di.GetFiles())
         {
-            Resolver.Log.Debug($"  - {f.Name}");
+            Log.Debug($"  - {f.Name}");
         }
-
         foreach (var d in di.GetDirectories())
         {
             DisplayTree(d);

--- a/Source/Meadow.Core/Cloud/MeadowCloudUpdateService.cs
+++ b/Source/Meadow.Core/Cloud/MeadowCloudUpdateService.cs
@@ -205,7 +205,6 @@ internal class MeadowCloudUpdateService : IUpdateService
 
         try
         {
-            // Add timeout settings to HttpClient
             using var httpClient = new HttpClient();
 
             // Set timeout for the entire operation
@@ -220,12 +219,10 @@ internal class MeadowCloudUpdateService : IUpdateService
             // Configure the HTTP range header to indicate resumption of partial download, starting from 
             // the 'EOF' byte position of the partial download and extending to the end of the content.
             using var fileStream = Store.StartMpak();
-            Log.Debug($"Resuming from offset {fileStream.Length}");
+            Log.Debug($"Resuming from offset {fileStream.Length}", "update service");
             request.Headers.Range = new System.Net.Http.Headers.RangeHeaderValue(fileStream.Length, null);
 
-            // Create a cancellation token with timeout to prevent stalled downloads
-            using var downloadCts = new CancellationTokenSource();
-            var response = await httpClient.SendAsync(request, HttpCompletionOption.ResponseHeadersRead, downloadCts.Token);
+            var response = await httpClient.SendAsync(request, HttpCompletionOption.ResponseHeadersRead, new CancellationTokenSource(millisecondsDelay: 15000).Token);
             var contentLength = response.Content.Headers.ContentLength;
             if (contentLength.HasValue)
             {
@@ -233,13 +230,14 @@ internal class MeadowCloudUpdateService : IUpdateService
                 // Then, to determine the total file size, the Content-Length from the first download attempt is used.
                 if (message.FileSize == 0)
                     message.FileSize = contentLength.Value;
-                Log.Debug($"File size: {message.FileSize:N0} bytes.");
+                Log.Debug($"File size: {message.FileSize:N0} bytes.", "update service");
             }
 
             using var stream = await response.Content.ReadAsStreamAsync();
             int bytesRead;
 
-            // Add a timer to detect stalled downloads
+            // Create a cancellation token with timeout to prevent stalled downloads
+            using var downloadCts = new CancellationTokenSource();
             var lastProgressTime = DateTime.UtcNow;
             using var progressTimer = new Timer(_ =>
             {
@@ -270,12 +268,12 @@ internal class MeadowCloudUpdateService : IUpdateService
                 update_cancellation.Token.ThrowIfCancellationRequested();
                 cancel.Token.ThrowIfCancellationRequested();
 
-                Log.Trace($"Download progress: {totalBytesDownloaded:N0} bytes downloaded");
+                Log.Trace($"Download progress: {totalBytesDownloaded:N0} bytes downloaded", "update service");
             }
             await writeTask; // wait for last write to disk task to complete
 
             sw.Stop();
-            Log.Debug($"Download complete: {totalBytesDownloaded} bytes in {sw.Elapsed.TotalSeconds} secs.");
+            Log.Debug($"Download complete: {totalBytesDownloaded} bytes in {sw.Elapsed.TotalSeconds} secs.", "update service");
         }
 
         catch (OperationCanceledException)

--- a/Source/Meadow.Core/Cloud/UpdateStore.cs
+++ b/Source/Meadow.Core/Cloud/UpdateStore.cs
@@ -1,236 +1,156 @@
 ﻿using System;
-using System.Collections;
-using System.Collections.Generic;
 using System.IO;
 using System.IO.Hashing;
-using System.Linq;
-using System.Threading.Tasks;
 
 namespace Meadow.Update;
 
+using static Resolver;
+
 /// <summary>
-/// A local store for holding information about available and applied Updates
+/// A local persistent store for holding and accounting for Meadow update data
 /// </summary>
-public class UpdateStore : IEnumerable<UpdateInfo>
+internal class UpdateStore
 {
     private const string UpdateInfoFileName = "info.json";
+    private const string MpakPartialFileName = "mpak.partial";
+    private const string MpakFileName = "mpak.zip";
 
-    private readonly List<UpdateMessage> _updates = new();
     private readonly DirectoryInfo _storeDirectory;
+    private readonly string manifest_path;
+    private readonly string mpak_partial_path;
+    private readonly string mpak_path;
 
-    internal UpdateStore(string dataDirectory)
+    private FileStream? mpak_stream;
+
+    internal enum States { Empty, Manifest, Mpak };
+
+    internal UpdateMessage? Manifest;
+    internal string MpakPath
     {
-        // each update is a subdirectory of the store
-        _storeDirectory = new DirectoryInfo(dataDirectory);
+        get
+        {
+            if (State >= States.Mpak)
+                return mpak_path;
+            else throw new InvalidOperationException("Mpak not available.");
+        }
+    }
+
+    internal States State
+    {
+        get
+        {
+            var state = States.Empty;
+            try
+            {
+                if (File.Exists(manifest_path))
+                {
+                    var json = File.ReadAllText(manifest_path);
+                    Manifest = JsonSerializer.Deserialize<UpdateMessage>(json);
+                    state = States.Manifest;
+
+                    if (File.Exists(mpak_path))
+                    {
+                        if (GetFileHash(mpak_path) != Manifest.Crc)
+                        {
+                            Log.Warn("MPAK file hash does not match manifest CRC");
+                        }
+                        state = States.Mpak;
+                    }
+                }
+            }
+            catch (Exception e)
+            {
+                Clear();
+                Log.Error(e, "update store");
+            }
+            return state;
+        }
+        set
+        {
+            if (value == States.Empty)
+                Clear();
+            else
+                throw new InvalidOperationException();
+        }
+    }
+
+    internal UpdateStore(string path)
+    {
+        _storeDirectory = new DirectoryInfo(path);
         if (!_storeDirectory.Exists)
-        {
             _storeDirectory.Create();
-        }
-        else
-        {
-            // load from persistence
-            foreach (var d in _storeDirectory.GetDirectories())
-            {
-                // load the update info
-                var infoFile = d.GetFiles(UpdateInfoFileName).FirstOrDefault();
-                if (infoFile == null)
-                {
-                    // not a valid update
-                    // TODO: should we delete this folder?
-                    Resolver.Log.Warn($"Invalid Update: {d.Name}");
-                    continue;
-                }
-                UpdateMessage? info;
-                try
-                {
-                    var json = File.ReadAllText(infoFile.FullName);
-                    info = Resolver.JsonSerializer.Deserialize<UpdateMessage>(json);
 
-                    if (info == null)
-                    {
-                        Resolver.Log.Warn($"Invalid update json for {d.Name}");
-                        continue;
-                    }
-                }
-                catch (Exception ex)
-                {
-                    Resolver.Log.Warn($"Error getting update info for {d.Name}: {ex.Message}");
-                    continue;
-                }
-
-                // has this update already been applied?
-                var zipInfo = d.GetFiles("*.zip").FirstOrDefault();
-
-                if (info.Applied)
-                {
-                    // it's been applied.  Make sure no binary is still hanging around consuming space
-                    if (zipInfo != null)
-                    {
-                        try
-                        {
-                            zipInfo.Delete();
-                        }
-                        catch (Exception ex)
-                        {
-                            Resolver.Log.Warn($"Error deleting update binary for {d.Name}: {ex.Message}");
-                        }
-                    }
-                }
-                else
-                {
-                    info.Retrieved = false;
-
-                    // has this update already been retrieved?  double check, don't just believe the info
-                    // we have valid info, have we downloaded?
-                    if (zipInfo != null)
-                    {
-                        // TODO: check the download hash to make sure it's good?
-
-                        info.Retrieved = true;
-                    }
-                }
-
-                _updates.Add(info);
-            }
-        }
-    }
-
-    internal void Add(UpdateMessage info)
-    {
-        info.Retrieved = false;
-        info.Applied = false;
-        SaveOrUpdateMessage(info);
-        _updates.Add(info);
-    }
-
-    private void SaveOrUpdateMessage(UpdateMessage info)
-    {
-        // create a folder
-        var di = _storeDirectory.CreateSubdirectory(info.ID);
-
-        // persist this update
-        var json = Resolver.JsonSerializer.Serialize(info);
-
-        var dest = Path.Combine(di.FullName, UpdateInfoFileName);
-        File.WriteAllText(dest, json);
-    }
-
-    private void SaveOrUpdateMessage(UpdateInfo info)
-    {
-        // create a folder
-        var di = _storeDirectory.CreateSubdirectory(info.ID);
-
-        // persist this update
-        var json = Resolver.JsonSerializer.Serialize(info);
-
-        var dest = Path.Combine(di.FullName, UpdateInfoFileName);
-        File.WriteAllText(dest, json);
+        manifest_path = Path.Join(path, UpdateInfoFileName);
+        mpak_partial_path = Path.Join(path, MpakPartialFileName);
+        mpak_path = Path.Join(path, MpakFileName);
     }
 
     /// <summary>
-    /// Deletes all local update archives and information
+    /// Adds a manifest to the update store.
     /// </summary>
-    public void Clear()
+    /// <param name="manifest_path">The path to the manifest file.</param>
+    public void AddManifest(string manifest_path)
     {
-        _updates.Clear();
-        foreach (var d in _storeDirectory.EnumerateDirectories())
-        {
-            foreach (var file in d.EnumerateFiles())
-            {
-                file.Delete();
-            }
-            d.Delete();
-        }
-    }
+        Log.Debug("AddManifest()", "update store");
+        if (State != States.Empty)
+            throw new Exception("Cannot add a manifest, store already includes an update");
 
-    internal bool TryGetMessage(string id, out UpdateMessage? message)
-    {
-        message = _updates.FirstOrDefault(m => m.MpakID == id);
-        return message != null;
-    }
+        Log.Debug($"{Path.GetFullPath(manifest_path)} -> {this.manifest_path}");
 
-    /// <summary>
-    /// Gets the full path to the provided update archive 
-    /// </summary>
-    /// <param name="updateID">The ID of the archive of interest</param>
-    public string? GetUpdateArchivePath(string updateID)
-    {
-        var dest = Path.Combine(_storeDirectory.FullName, updateID);
-        var di = new DirectoryInfo(dest);
-        if (!di.Exists)
-        {
-            return null;
-        }
-
-        return di.GetFiles("*.zip").FirstOrDefault()?.FullName;
-    }
-
-    internal FileStream GetUpdateFileStream(string updateID)
-    {
-        // make sure the update folder exists
-        var dest = Path.Combine(_storeDirectory.FullName, updateID);
-        var di = new DirectoryInfo(dest);
-        if (!di.Exists)
-        {
-            di.Create();
-        }
-
-        var filePath = Path.Combine(dest, $"{updateID}.zip");
-        var fi = new FileInfo(filePath);
-        if (fi.Exists)
-        {
-            // Continue the download, instead of discarding the downloaded bytes
-            Resolver.Log.Trace($"Resuming download from existing file: {filePath}. Appending to continue.");
-            return fi.Open(FileMode.Append, FileAccess.Write);
-        }
-
-        return fi.Create();
+        File.Move(manifest_path, this.manifest_path);
     }
 
     /// <summary>
     /// Calculates the CRC32 hash of a file
     /// </summary>
     /// <param name="file">The file to hash</param>
-    public async Task<string> GetFileHash(FileInfo file)
+    private string GetFileHash(string file)
     {
         var crc32 = new Crc32();
-
-        using var fs = File.OpenRead(file.FullName);
-        await crc32.AppendAsync(fs);
+        using var fs = File.OpenRead(file);
+        crc32.Append(fs);
 
         var checkSum = crc32.GetCurrentHash();
         Array.Reverse(checkSum); // make big endian
         return BitConverter.ToString(checkSum).Replace("-", "").ToLower();
     }
 
-    internal void SetRetrieved(UpdateMessage message)
+    /// <summary>
+    /// Deletes all local update archives and information
+    /// </summary>
+    private void Clear()
     {
-        message.Retrieved = true;
-        SaveOrUpdateMessage(message);
+        MeadowOS.DeleteDirectoryContents(_storeDirectory, deleteDirectory: false);
     }
 
-    internal void SetApplied(UpdateInfo message)
+    internal FileStream StartMpak()
     {
-        // delete the binary to save space
-        var dest = Path.Combine(_storeDirectory.FullName, message.ID);
-        var fi = new FileInfo(Path.Combine(dest, $"{message.ID}.zip"));
+        Log.Debug("StartMpak()", "update store");
+        if (State != States.Manifest)
+            throw new Exception("Cannot add a MPAK, no manifest in store");
+
+        var fi = new FileInfo(mpak_partial_path);
         if (fi.Exists)
         {
-            fi.Delete();
+            // Continue the download, instead of discarding the downloaded bytes
+            Log.Debug($"Resuming download from existing file: {fi.FullName}. Appending to continue.");
+            mpak_stream = fi.Open(FileMode.Append, FileAccess.Write);
         }
-
-        message.Applied = true;
-        SaveOrUpdateMessage(message);
+        else
+        {
+            mpak_stream = fi.Create();
+        }
+        return mpak_stream;
     }
 
-    /// <inheritdoc/>
-    public IEnumerator<UpdateInfo> GetEnumerator()
+    internal void CompleteMpak()
     {
-        return _updates.GetEnumerator();
-    }
+        Log.Debug("CompleteMpak()", "update store");
+        if (State != States.Manifest)
+            throw new Exception("Cannot add a MPAK, no manifest in store");
 
-    IEnumerator IEnumerable.GetEnumerator()
-    {
-        return GetEnumerator();
+        mpak_stream!.Close();
+        File.Copy(mpak_partial_path, mpak_path);
+        File.Delete(mpak_partial_path);
     }
 }

--- a/Source/Meadow.Core/MeadowOS.cs
+++ b/Source/Meadow.Core/MeadowOS.cs
@@ -6,6 +6,7 @@ using Meadow.Update;
 using System;
 using System.Collections.Generic;
 using System.IO;
+using System.IO.Compression;
 using System.Linq;
 using System.Reflection;
 using System.Runtime.InteropServices;
@@ -967,6 +968,70 @@ public static partial class MeadowOS
             {
                 d.Delete();
             }
+        }
+    }
+
+    /// <summary>
+    /// Safely extracts a ZIP file to a target directory by using a temporary directory
+    /// and then atomically renaming it to the target location.
+    /// </summary>
+    /// <param name="file">Path to the ZIP file to extract</param>
+    /// <param name="empty_target_dir">Path to the target directory (must be empty or non-existent)</param>
+    /// <exception cref="ArgumentException">Thrown if the ZIP file doesn't exist or target directory is not empty</exception>
+    /// <exception cref="IOException">Thrown if extraction or directory operations fail</exception>
+    public static void SafelyExtractZIPFile(string file, string empty_target_dir)
+    {
+        if (!File.Exists(file))
+        {
+            throw new ArgumentException($"ZIP file does not exist: {file}");
+        }
+
+        // Delete the target directory if it exists 
+        DirectoryInfo existing_target_dir = new DirectoryInfo(empty_target_dir);
+        DeleteDirectoryContents(existing_target_dir);
+
+        // Create a temporary directory with a unique name in the system temp location
+        string tempDirectory = Path.Combine(
+            FileSystem.TempDirectory, 
+            "zip_extract_" + Guid.NewGuid().ToString("N"));
+
+        try
+        {
+            // Create the temp directory
+            Directory.CreateDirectory(tempDirectory);
+
+            // Extract the ZIP file
+            Resolver.Log.Info($"Extracting ZIP file {file} to temporary location {tempDirectory}", MessageGroup.Core);
+            ZipFile.ExtractToDirectory(file, tempDirectory);
+
+            // Ensure the parent directory of the target exists
+            string parentDir = Path.GetDirectoryName(empty_target_dir);
+            if (!string.IsNullOrEmpty(parentDir) && !Directory.Exists(parentDir))
+            {
+                Directory.CreateDirectory(parentDir);
+            }
+
+            // Move the temporary directory to the target directory
+            Resolver.Log.Info($"Moving extracted contents from {tempDirectory} to {empty_target_dir}", MessageGroup.Core);
+            Directory.Move(tempDirectory, empty_target_dir);
+        }
+        catch (Exception ex)
+        {
+            // Clean up the temp directory if something went wrong
+            if (Directory.Exists(tempDirectory))
+            {
+                try
+                {
+                    Directory.Delete(tempDirectory, true);
+                }
+                catch
+                {
+                    // Best effort cleanup - ignore errors during cleanup
+                }
+            }
+
+            Resolver.Log.Error($"Failed to extract ZIP file: {ex.Message}", MessageGroup.Core);
+            throw; // Re-throw the exception for the caller to handle
         }
     }
 }

--- a/Source/Meadow.Core/MeadowOS.cs
+++ b/Source/Meadow.Core/MeadowOS.cs
@@ -14,6 +14,8 @@ using System.Threading;
 using System.Threading.Tasks;
 using static Meadow.Logging.Logger;
 using RTI = System.Runtime.InteropServices.RuntimeInformation;
+using System.Runtime.CompilerServices;
+
 namespace Meadow;
 
 /// <summary>
@@ -969,6 +971,8 @@ public static partial class MeadowOS
                 d.Delete();
             }
         }
+        if (deleteDirectory)
+            di.Delete();
     }
 
     /// <summary>
@@ -976,10 +980,10 @@ public static partial class MeadowOS
     /// and then atomically renaming it to the target location.
     /// </summary>
     /// <param name="file">Path to the ZIP file to extract</param>
-    /// <param name="empty_target_dir">Path to the target directory (must be empty or non-existent)</param>
+    /// <param name="nonexisting_target_dir">Path to the target directory (must be empty or non-existent)</param>
     /// <exception cref="ArgumentException">Thrown if the ZIP file doesn't exist or target directory is not empty</exception>
     /// <exception cref="IOException">Thrown if extraction or directory operations fail</exception>
-    public static void SafelyExtractZIPFile(string file, string empty_target_dir)
+    public static void SafelyExtractZIPFile(string file, string nonexisting_target_dir)
     {
         if (!File.Exists(file))
         {
@@ -987,12 +991,12 @@ public static partial class MeadowOS
         }
 
         // Delete the target directory if it exists 
-        DirectoryInfo existing_target_dir = new DirectoryInfo(empty_target_dir);
-        DeleteDirectoryContents(existing_target_dir);
+        DirectoryInfo existing_target_dir = new DirectoryInfo(nonexisting_target_dir);
+        DeleteDirectoryContents(existing_target_dir, deleteDirectory: true);
 
         // Create a temporary directory with a unique name in the system temp location
         string tempDirectory = Path.Combine(
-            FileSystem.TempDirectory, 
+            FileSystem.TempDirectory,
             "zip_extract_" + Guid.NewGuid().ToString("N"));
 
         try
@@ -1005,15 +1009,15 @@ public static partial class MeadowOS
             ZipFile.ExtractToDirectory(file, tempDirectory);
 
             // Ensure the parent directory of the target exists
-            string parentDir = Path.GetDirectoryName(empty_target_dir);
+            string parentDir = Path.GetDirectoryName(nonexisting_target_dir);
             if (!string.IsNullOrEmpty(parentDir) && !Directory.Exists(parentDir))
             {
                 Directory.CreateDirectory(parentDir);
             }
 
             // Move the temporary directory to the target directory
-            Resolver.Log.Info($"Moving extracted contents from {tempDirectory} to {empty_target_dir}", MessageGroup.Core);
-            Directory.Move(tempDirectory, empty_target_dir);
+            Resolver.Log.Info($"Moving extracted contents from {tempDirectory} to {nonexisting_target_dir}", MessageGroup.Core);
+            Directory.Move(tempDirectory, nonexisting_target_dir);
         }
         catch (Exception ex)
         {

--- a/Source/Meadow.Core/MeadowOS.cs
+++ b/Source/Meadow.Core/MeadowOS.cs
@@ -857,12 +857,6 @@ public static partial class MeadowOS
     {
         AppAbort.Cancel(true);
 
-        // stop the update service
-        if (Resolver.Services.Get<IMeadowCloudService>() is { } cloudService)
-        {
-            cloudService.Stop();
-        }
-
         // schedule a device restart if possible and if the user hasn't disabled it
         ScheduleRestart();
 


### PR DESCRIPTION
 **_Needs https://github.com/WildernessLabs/Meadow.Contracts/pull/300_** 

Tested on Thurston PUD prototype.

MeadowCloudUpdateService.cs:

* Rewrote OTA progress loop for resilience and cancellability
* OTA no longer needs event buy-in from App, but can still be cancelled
* Multiple update requests will be resolved by having the last one be honored and all others cancelled
* Added stall detection and infinite retries for update download
* Using atomic operations to apply the update (see notes)

UpdateStore.cs:

* Now only stores up to one full update
* State machine detects partial updates to resume from persistent storage
* Auto-validating: Invalid updates are discarded

Notes:

* Atomic filesystem operations must be used for the update service to be fully resilient to corruption due to losing power. At OS 2.2, we have a bug that causes File.Move() to crash and never translate to the atomic (or at worst, near-atomic) POSIX rename(). Beginning with OS 2.3, this bug should be fixed.

* Hard power failure seems to cause all bytes to be lost from partial download files. Ideally this shouldn't happen - the data loss is partial. Can probably be mitigated by closing and re-opening the filestream for every chunk.

* Update service no longer stops when the app stops.