### PR TITLE
Add device reset failsafe for Meadow.Cloud connection failures

### DIFF
--- a/Source/Meadow.Core/Cloud/MeadowCloudConnectionService.cs
+++ b/Source/Meadow.Core/Cloud/MeadowCloudConnectionService.cs
@@ -64,6 +64,9 @@ internal class MeadowCloudConnectionService : IMeadowCloudService
     /// <inheritdoc/>
     public bool IsEnabled { get; private set; }
 
+    // Track the last time we were connected
+    private DateTime _lastConnectedTime = DateTime.UtcNow;
+
     internal MeadowCloudConnectionService(IMeadowCloudSettings settings)
     {
         Settings = settings;
@@ -288,10 +291,25 @@ internal class MeadowCloudConnectionService : IMeadowCloudService
 
         var stopwatch = new Stopwatch();
 
+        Resolver.Device!.PlatformOS.TimeChanged += (_) =>
+        {
+            // gotta reset the last connect time
+            _lastConnectedTime = DateTime.UtcNow;
+        };
+
         // update state machine
         while (!_stopService)
         {
             Resolver.Log.Trace($"connection state machine heartbeat: {ConnectionState}", "cloud");
+
+            // Restart device if not connected for more than the configured time
+            if ((DateTime.UtcNow - _lastConnectedTime).TotalMinutes > Settings.MaximumDisconnectTimeMinutes)
+            {
+                Resolver.Log.Error($"Device has not been connected to Meadow.Cloud for more than {Settings.MaximumDisconnectTimeMinutes} minutes. Restarting device...");
+                Resolver.Device?.PlatformOS.Reset();
+                return;
+            }
+
             switch (ConnectionState)
             {
                 case CloudConnectionState.Disconnected:
@@ -482,6 +500,7 @@ internal class MeadowCloudConnectionService : IMeadowCloudService
                     }
                     break;
                 case CloudConnectionState.Connected:
+                    _lastConnectedTime = DateTime.UtcNow; // Update last connected time
                     if (_firstConection)
                     {
                         if (SendCrashReports())

--- a/Source/Meadow.Core/Configuration/MeadowCloudSettings.cs
+++ b/Source/Meadow.Core/Configuration/MeadowCloudSettings.cs
@@ -16,4 +16,6 @@ internal class MeadowCloudSettings : IMeadowCloudSettings
     public int ConnectRetrySeconds { get; set; } = 15;
     public int AuthTimeoutSeconds { get; set; } = 120;
     public int MaxQueueDepth { get; set; } = CloudDataQueue.DefaultQueueDepth;
+
+    public int MaximumDisconnectTimeMinutes { get; set; } = 180;
 }

--- a/Source/Meadow.Core/NtpClientBase.cs
+++ b/Source/Meadow.Core/NtpClientBase.cs
@@ -26,7 +26,11 @@ public abstract class NtpClientBase : INtpClient
     /// Raises the TimeChanged event with a given time
     /// </summary>
     /// <param name="utcTime">The new time</param>
-    protected void RaiseTimeChanged(DateTime utcTime) => TimeChanged?.Invoke(utcTime);
+    protected void RaiseTimeChanged(DateTime utcTime)
+    {
+        TimeChanged?.Invoke(utcTime);
+        Resolver.Device.PlatformOS.RaiseTimeChanged(utcTime);
+    }
 
     /// <inheritdoc/>
     public Task<bool> Synchronize(string? ntpServer = null)

--- a/Source/implementations/f7/Meadow.F7/F7PlatformOS.cs
+++ b/Source/implementations/f7/Meadow.F7/F7PlatformOS.cs
@@ -201,7 +201,8 @@ public partial class F7PlatformOS : IPlatformOS
         return size;
     }
 
-    internal void RaiseTimeChanged(DateTime utcTime)
+    /// <inheritdoc/>
+    public void RaiseTimeChanged(DateTime utcTime)
     {
         TimeChanged?.Invoke(utcTime);
     }

--- a/Source/implementations/f7/Meadow.F7/F7PlatformOS.cs
+++ b/Source/implementations/f7/Meadow.F7/F7PlatformOS.cs
@@ -102,7 +102,7 @@ public partial class F7PlatformOS : IPlatformOS
 
         Core.Interop.Nuttx.clock_settime(Core.Interop.Nuttx.clockid_t.CLOCK_REALTIME, ref ts);
 
-        TimeChanged?.Invoke(dateTime);
+        RaiseTimeChanged(dateTime);
     }
 
     /// <inheritdoc/>
@@ -199,5 +199,10 @@ public partial class F7PlatformOS : IPlatformOS
         }
 
         return size;
+    }
+
+    internal void RaiseTimeChanged(DateTime utcTime)
+    {
+        TimeChanged?.Invoke(utcTime);
     }
 }

--- a/Source/implementations/linux/Meadow.Linux/PlatformOS/LinuxPlatformOS.cs
+++ b/Source/implementations/linux/Meadow.Linux/PlatformOS/LinuxPlatformOS.cs
@@ -22,6 +22,12 @@ public class LinuxPlatformOS : IPlatformOS
     /// <inheritdoc/>
     public event TimeChangedEventHandler? TimeChanged;
 
+    /// <inheritdoc/>
+    public void RaiseTimeChanged(DateTime utcTime)
+    {
+        TimeChanged?.Invoke(utcTime);
+    }
+
 #pragma warning disable CS0067 // The event 'NmCliNetworkAdapter.NetworkConnecting' is never used
     /// <summary>
     /// Event raised before a software reset

--- a/Source/implementations/mac/Meadow.Mac/MacPlatformOS.cs
+++ b/Source/implementations/mac/Meadow.Mac/MacPlatformOS.cs
@@ -19,6 +19,12 @@ public class MacPlatformOS : IPlatformOS
     /// <inheritdoc/>
     public event TimeChangedEventHandler? TimeChanged;
 
+    /// <inheritdoc/>
+    public void RaiseTimeChanged(DateTime utcTime)
+    {
+        TimeChanged?.Invoke(utcTime);
+    }
+
     /// <summary>
     /// Event raised before a software reset.
     /// </summary>

--- a/Source/implementations/simulation/Meadow.Simulation/SimulatedPlatformOS.cs
+++ b/Source/implementations/simulation/Meadow.Simulation/SimulatedPlatformOS.cs
@@ -14,6 +14,12 @@ public class SimulatedPlatformOS : IPlatformOS
     /// <inheritdoc/>
     public event TimeChangedEventHandler? TimeChanged;
 
+    /// <inheritdoc/>
+    public void RaiseTimeChanged(DateTime utcTime)
+    {
+        TimeChanged?.Invoke(utcTime);
+    }
+
     /// <summary>
     /// Event raised before a software reset
     /// </summary>

--- a/Source/implementations/windows/Meadow.Windows/WindowsPlatformOS.cs
+++ b/Source/implementations/windows/Meadow.Windows/WindowsPlatformOS.cs
@@ -19,6 +19,12 @@ public class WindowsPlatformOS : IPlatformOS
     private WindowsNtpClient _ntpClient;
 
     /// <inheritdoc/>
+    public void RaiseTimeChanged(DateTime utcTime)
+    {
+        TimeChanged?.Invoke(utcTime);
+    }
+
+    /// <inheritdoc/>
     public event TimeChangedEventHandler? TimeChanged;
 
     /// <summary>


### PR DESCRIPTION
Add logic to track the last time a connection was established, and if more than 3 hours (180 minutes) have passed without a connection, restart the device.

Copilot prompt: Make the connection service restart the device if it's been more than 3 hours without a connection

* Added edge case handling for when the Meadow clock has be re-set.