### PR TITLE
Add CRC validation to SafeDownloadFile()

### DIFF
--- a/Source/Meadow.Core/Cloud/MeadowCloudUpdateService.cs
+++ b/Source/Meadow.Core/Cloud/MeadowCloudUpdateService.cs
@@ -227,14 +227,60 @@ internal class MeadowCloudUpdateService : IUpdateService
 
             using var sendCts = new CancellationTokenSource(millisecondsDelay: 15000);
             var response = await httpClient.SendAsync(request, HttpCompletionOption.ResponseHeadersRead, sendCts.Token);
-            var contentLength = response.Content.Headers.ContentLength;
-            if (contentLength.HasValue)
+
+            var totalContentLength = response.Content.Headers.ContentRange?.Length;
+            var contentDigest = response.Headers.GetContentDigests().FirstOrDefault();
+
+            // Handle RequestedRangeNotSatisfiable which means the either the file is fully downloaded, or
+            // the file on disk is larger than the file on the server (indicating an incorrect file)
+            if (response.StatusCode == System.Net.HttpStatusCode.RequestedRangeNotSatisfiable)
             {
-                // Content-Length indicates the remaining bytes to download, as the Range header may change after retries.
-                // Then, to determine the total file size, the Content-Length from the first download attempt is used.
-                if (message.FileSize == 0)
-                    message.FileSize = contentLength.Value;
-                Log.Debug($"File size: {message.FileSize:N0} bytes.", "update service");
+                Log.Info("Server responded with 416 Range Not Satisfiable. Assuming file is fully downloaded.", "update service");
+                if (totalContentLength.HasValue && fileStream.Length != totalContentLength.Value)
+                {
+                    fileStream.Close();
+                    Store.DeleteMpak();
+                    throw new MpakValidationFailedException($"Download size mismatch. Expected {totalContentLength.Value:N0} bytes but received {fileStream.Length:N0} bytes.");
+                }
+
+                fileStream.Close();
+                if (contentDigest != null && !Store.ValidateMpak(contentDigest.Algorithm, contentDigest.Value, out var actualHash1))
+                {
+                    Store.DeleteMpak();
+                    throw new MpakValidationFailedException($"CRC hash mismatch. Expected {contentDigest.Value} but rececived {actualHash1}.");
+                }
+
+                return;
+            }
+
+            response.EnsureSuccessStatusCode();
+
+            // Handle Content-Range header (for resumable downloads)
+            var rangeContentLength = response.Content.Headers.ContentLength;
+
+            // Determine the total file size
+            if (totalContentLength.HasValue)
+            {
+                // Content-Range header provides the total file size (preferred for resumable downloads)
+                message.FileSize = totalContentLength.Value;
+                Log.Debug($"Total file size from Content-Range: {message.FileSize:N0} bytes.", "update service");
+            }
+            else if (rangeContentLength.HasValue && fileStream.Length == 0)
+            {
+                // First download attempt - Content-Length is the total size
+                message.FileSize = rangeContentLength.Value;
+                Log.Debug($"Total file size from Content-Length: {message.FileSize:N0} bytes.", "update service");
+            }
+            else if (!rangeContentLength.HasValue)
+            {
+                Log.Warn("Server did not provide Content-Length header. Progress tracking may be inaccurate.", "update service");
+                // FileSize remains at its previous value or 0 if not set
+            }
+
+            // Validate that we got some length information for resumed downloads
+            if (fileStream.Length > 0 && !totalContentLength.HasValue && !rangeContentLength.HasValue)
+            {
+                Log.Warn("Resuming download but server provided no length headers. Download may be incomplete.", "update service");
             }
 
             using var stream = await response.Content.ReadAsStreamAsync();
@@ -275,15 +321,37 @@ internal class MeadowCloudUpdateService : IUpdateService
                 Log.Trace($"Download progress: {totalBytesDownloaded:N0} bytes downloaded", "update service");
             }
             await writeTask; // wait for last write to disk task to complete
+            
+            // Validate download completion
+            if (rangeContentLength.HasValue && totalBytesDownloaded != rangeContentLength.Value)
+            {
+                fileStream.Close();
+                Store.DeleteMpak();
+                throw new MpakValidationFailedException($"Download size mismatch. Expected {rangeContentLength.Value:N0} bytes but received {totalBytesDownloaded:N0} bytes.");
+            }
+
+            // Validate CRC if provided
+            fileStream.Close();
+            if (contentDigest != null && !Store.ValidateMpak(contentDigest.Algorithm, contentDigest.Value, out var actualHash2))
+            {   
+                Store.DeleteMpak();
+                throw new MpakValidationFailedException($"CRC hash mismatch. Expected {contentDigest.Value} but rececived {actualHash2}.");
+            }
 
             sw.Stop();
             Log.Debug($"Download complete: {totalBytesDownloaded} bytes in {sw.Elapsed.TotalSeconds} secs.", "update service");
         }
-
         catch (OperationCanceledException)
         {
             sw.Stop();
             Log.Error($"Download timed out or cancelled after {sw.Elapsed.TotalSeconds:0} seconds", "update service");
+            await Task.Delay(RetryDelayMilliseconds);
+            throw;
+        }
+        catch (MpakValidationFailedException ex)
+        {
+            sw.Stop();
+            Log.Error($"Download failed mpak validation: {ex.Message}", "update service");
             await Task.Delay(RetryDelayMilliseconds);
             throw;
         }
@@ -374,4 +442,15 @@ internal class MeadowCloudUpdateService : IUpdateService
             DisplayTree(d);
         }
     }
+}
+
+/// <summary>
+/// 
+/// </summary>
+public class MpakValidationFailedException : Exception
+{
+    /// <summary>
+    /// 
+    /// </summary>
+    public MpakValidationFailedException(string message) : base(message) { }
 }

--- a/Source/Meadow.Core/Cloud/MeadowCloudUpdateService.cs
+++ b/Source/Meadow.Core/Cloud/MeadowCloudUpdateService.cs
@@ -241,12 +241,10 @@ internal class MeadowCloudUpdateService : IUpdateService
                 Log.Info("Server responded with 416 Range Not Satisfiable. Assuming file is fully downloaded.", "update service");
                 if (totalContentLength.HasValue && fileStream.Length != totalContentLength.Value)
                 {
-                    fileStream.Close();
                     Store.DeleteMpak();
                     throw new MpakValidationFailedException($"Download size mismatch. Expected {totalContentLength.Value:N0} bytes but received {fileStream.Length:N0} bytes.");
                 }
 
-                fileStream.Close();
                 if (contentDigest != null && !Store.ValidateMpak(contentDigest.Algorithm, contentDigest.Value, out var actualHash1))
                 {
                     Store.DeleteMpak();
@@ -321,24 +319,22 @@ internal class MeadowCloudUpdateService : IUpdateService
                 Log.Trace($"Download progress: {totalBytesDownloaded:N0} bytes downloaded", "update service");
             }
             await writeTask; // wait for last write to disk task to complete
-            
+            sw.Stop();
+
             // Validate download completion
             if (rangeContentLength.HasValue && totalBytesDownloaded != rangeContentLength.Value)
             {
-                fileStream.Close();
                 Store.DeleteMpak();
                 throw new MpakValidationFailedException($"Download size mismatch. Expected {rangeContentLength.Value:N0} bytes but received {totalBytesDownloaded:N0} bytes.");
             }
 
             // Validate CRC if provided
-            fileStream.Close();
             if (contentDigest != null && !Store.ValidateMpak(contentDigest.Algorithm, contentDigest.Value, out var actualHash2))
             {   
                 Store.DeleteMpak();
                 throw new MpakValidationFailedException($"CRC hash mismatch. Expected {contentDigest.Value} but received {actualHash2}.");
             }
 
-            sw.Stop();
             Log.Debug($"Download complete: {totalBytesDownloaded} bytes in {sw.Elapsed.TotalSeconds} secs.", "update service");
         }
         catch (OperationCanceledException)

--- a/Source/Meadow.Core/Cloud/MeadowCloudUpdateService.cs
+++ b/Source/Meadow.Core/Cloud/MeadowCloudUpdateService.cs
@@ -238,23 +238,9 @@ internal class MeadowCloudUpdateService : IUpdateService
             if (response.StatusCode == System.Net.HttpStatusCode.RequestedRangeNotSatisfiable)
             {
                 Log.Info("Server responded with 416 Range Not Satisfiable. Assuming file is fully downloaded.", "update service");
-                if (totalContentLength.HasValue && fileStream.Length != totalContentLength.Value)
-                {
-                    Store.DeleteMpak();
-                    throw new MpakValidationFailedException($"Download size mismatch. Expected {totalContentLength.Value:N0} bytes but received {fileStream.Length:N0} bytes.");
-                }
 
-                if (contentDigest != null && !Store.ValidateMpak(contentDigest.Algorithm, contentDigest.Value, out var actualHash1))
-                {
-                    Store.DeleteMpak();
-                    throw new MpakValidationFailedException($"CRC hash mismatch. Expected {contentDigest.Value} but received {actualHash1}.");
-                }
-                else if (contentDigest == null)
-                {
-                    Log.Debug($"Skipping CRC hash check. Hash was not provided by server.", "update service");
-                }
-
-                Log.Debug($"Download validation successful.", "update service");
+                // Validate download completion
+                PerformMpakValidation(contentDigest, totalContentLength, fileStream.Length);
                 return;
             }
 
@@ -327,24 +313,7 @@ internal class MeadowCloudUpdateService : IUpdateService
             Log.Debug($"Download complete: {totalBytesDownloaded} bytes in {sw.Elapsed.TotalSeconds} secs.", "update service");
 
             // Validate download completion
-            if (rangeContentLength.HasValue && totalBytesDownloaded != rangeContentLength.Value)
-            {
-                Store.DeleteMpak();
-                throw new MpakValidationFailedException($"Download size mismatch. Expected {rangeContentLength.Value:N0} bytes but received {totalBytesDownloaded:N0} bytes.");
-            }
-
-            // Validate CRC if provided
-            if (contentDigest != null && !Store.ValidateMpak(contentDigest.Algorithm, contentDigest.Value, out var actualHash2))
-            {   
-                Store.DeleteMpak();
-                throw new MpakValidationFailedException($"CRC hash mismatch. Expected {contentDigest.Value} but received {actualHash2}.");
-            }
-            else if (contentDigest == null)
-            {
-                Log.Debug($"Skipping CRC hash check. Hash was not provided by server.", "update service");
-            }
-
-            Log.Debug($"Download validation successful.", "update service");
+            PerformMpakValidation(contentDigest, rangeContentLength, totalBytesDownloaded);
         }
         catch (OperationCanceledException)
         {
@@ -446,5 +415,28 @@ internal class MeadowCloudUpdateService : IUpdateService
         {
             DisplayTree(d);
         }
+    }
+
+    private void PerformMpakValidation(ContentDigestItem? contentDigest, long? expectedDownloadSize, long actualDownloadSize)
+    {
+        // Validate download size against expected size, if provided
+        if (expectedDownloadSize.HasValue && expectedDownloadSize.Value != actualDownloadSize)
+        {
+            Store.DeleteMpak();
+            throw new MpakValidationFailedException($"Download size mismatch. Expected {expectedDownloadSize.Value:N0} bytes but received {actualDownloadSize:N0} bytes.");
+        }
+
+        // Validate CRC, if provided
+        if (contentDigest != null && !Store.ValidateMpak(contentDigest.Algorithm, contentDigest.Value, out var actualHash))
+        {
+            Store.DeleteMpak();
+            throw new MpakValidationFailedException($"CRC hash mismatch. Expected {contentDigest.Value} but received {actualHash}.");
+        }
+        else if (contentDigest == null)
+        {
+            Log.Debug($"Skipping CRC hash check. Hash was not provided by server.", "update service");
+        }
+
+        Log.Debug($"Download validation successful.", "update service");
     }
 }

--- a/Source/Meadow.Core/Cloud/MeadowCloudUpdateService.cs
+++ b/Source/Meadow.Core/Cloud/MeadowCloudUpdateService.cs
@@ -228,6 +228,8 @@ internal class MeadowCloudUpdateService : IUpdateService
             using var sendCts = new CancellationTokenSource(millisecondsDelay: 15000);
             var response = await httpClient.SendAsync(request, HttpCompletionOption.ResponseHeadersRead, sendCts.Token);
 
+            // Handle Content-Range header (for resumable downloads)
+            var rangeContentLength = response.Content.Headers.ContentLength;
             var totalContentLength = response.Content.Headers.ContentRange?.Length;
             var contentDigest = response.Headers.GetContentDigests().FirstOrDefault();
 
@@ -254,9 +256,6 @@ internal class MeadowCloudUpdateService : IUpdateService
             }
 
             response.EnsureSuccessStatusCode();
-
-            // Handle Content-Range header (for resumable downloads)
-            var rangeContentLength = response.Content.Headers.ContentLength;
 
             // Determine the total file size
             if (totalContentLength.HasValue)

--- a/Source/Meadow.Core/Cloud/MeadowCloudUpdateService.cs
+++ b/Source/Meadow.Core/Cloud/MeadowCloudUpdateService.cs
@@ -231,8 +231,7 @@ internal class MeadowCloudUpdateService : IUpdateService
             // Handle Content-Range header (for resumable downloads)
             var rangeContentLength = response.Content.Headers.ContentLength;
             var totalContentLength = response.Content.Headers.ContentRange?.Length;
-            var contentDigests = response.Headers.GetContentDigests();
-            var contentDigest = contentDigests.Count > 0 ? contentDigests[0] : null;
+            var contentDigest = response.Headers.GetContentDigest();
 
             // Handle RequestedRangeNotSatisfiable which means the either the file is fully downloaded, or
             // the file on disk is larger than the file on the server (indicating an incorrect file)
@@ -250,7 +249,12 @@ internal class MeadowCloudUpdateService : IUpdateService
                     Store.DeleteMpak();
                     throw new MpakValidationFailedException($"CRC hash mismatch. Expected {contentDigest.Value} but received {actualHash1}.");
                 }
+                else if (contentDigest == null)
+                {
+                    Log.Debug($"Skipping CRC hash check. Hash was not provided by server.", "update service");
+                }
 
+                Log.Debug($"Download validation successful.", "update service");
                 return;
             }
 
@@ -320,6 +324,7 @@ internal class MeadowCloudUpdateService : IUpdateService
             }
             await writeTask; // wait for last write to disk task to complete
             sw.Stop();
+            Log.Debug($"Download complete: {totalBytesDownloaded} bytes in {sw.Elapsed.TotalSeconds} secs.", "update service");
 
             // Validate download completion
             if (rangeContentLength.HasValue && totalBytesDownloaded != rangeContentLength.Value)
@@ -334,8 +339,12 @@ internal class MeadowCloudUpdateService : IUpdateService
                 Store.DeleteMpak();
                 throw new MpakValidationFailedException($"CRC hash mismatch. Expected {contentDigest.Value} but received {actualHash2}.");
             }
+            else if (contentDigest == null)
+            {
+                Log.Debug($"Skipping CRC hash check. Hash was not provided by server.", "update service");
+            }
 
-            Log.Debug($"Download complete: {totalBytesDownloaded} bytes in {sw.Elapsed.TotalSeconds} secs.", "update service");
+            Log.Debug($"Download validation successful.", "update service");
         }
         catch (OperationCanceledException)
         {

--- a/Source/Meadow.Core/Cloud/MeadowCloudUpdateService.cs
+++ b/Source/Meadow.Core/Cloud/MeadowCloudUpdateService.cs
@@ -231,7 +231,8 @@ internal class MeadowCloudUpdateService : IUpdateService
             // Handle Content-Range header (for resumable downloads)
             var rangeContentLength = response.Content.Headers.ContentLength;
             var totalContentLength = response.Content.Headers.ContentRange?.Length;
-            var contentDigest = response.Headers.GetContentDigests().FirstOrDefault();
+            var contentDigests = response.Headers.GetContentDigests();
+            var contentDigest = contentDigests.Count > 0 ? contentDigests[0] : null;
 
             // Handle RequestedRangeNotSatisfiable which means the either the file is fully downloaded, or
             // the file on disk is larger than the file on the server (indicating an incorrect file)
@@ -249,7 +250,7 @@ internal class MeadowCloudUpdateService : IUpdateService
                 if (contentDigest != null && !Store.ValidateMpak(contentDigest.Algorithm, contentDigest.Value, out var actualHash1))
                 {
                     Store.DeleteMpak();
-                    throw new MpakValidationFailedException($"CRC hash mismatch. Expected {contentDigest.Value} but rececived {actualHash1}.");
+                    throw new MpakValidationFailedException($"CRC hash mismatch. Expected {contentDigest.Value} but received {actualHash1}.");
                 }
 
                 return;
@@ -334,7 +335,7 @@ internal class MeadowCloudUpdateService : IUpdateService
             if (contentDigest != null && !Store.ValidateMpak(contentDigest.Algorithm, contentDigest.Value, out var actualHash2))
             {   
                 Store.DeleteMpak();
-                throw new MpakValidationFailedException($"CRC hash mismatch. Expected {contentDigest.Value} but rececived {actualHash2}.");
+                throw new MpakValidationFailedException($"CRC hash mismatch. Expected {contentDigest.Value} but received {actualHash2}.");
             }
 
             sw.Stop();
@@ -441,15 +442,4 @@ internal class MeadowCloudUpdateService : IUpdateService
             DisplayTree(d);
         }
     }
-}
-
-/// <summary>
-/// 
-/// </summary>
-public class MpakValidationFailedException : Exception
-{
-    /// <summary>
-    /// 
-    /// </summary>
-    public MpakValidationFailedException(string message) : base(message) { }
 }

--- a/Source/Meadow.Core/Cloud/MpakValidationFailedException.cs
+++ b/Source/Meadow.Core/Cloud/MpakValidationFailedException.cs
@@ -1,0 +1,15 @@
+﻿using System;
+
+namespace Meadow;
+
+/// <summary>
+/// Exception thrown when validation of an mpak update package fails.
+/// </summary>
+public class MpakValidationFailedException : Exception
+{
+    /// <summary>
+    /// Initializes a new instance of the <see cref="MpakValidationFailedException"/> class with a specified error message describing the validation failure.
+    /// </summary>
+    /// <param name="message">The error message that explains the reason for the validation failure.</param>
+    public MpakValidationFailedException(string message) : base(message) { }
+}

--- a/Source/Meadow.Core/Cloud/UpdateStore.cs
+++ b/Source/Meadow.Core/Cloud/UpdateStore.cs
@@ -141,7 +141,7 @@ internal class UpdateStore
 
     internal void DeleteMpak()
     {
-        Log.Debug("ResetMpak()", "update store");
+        Log.Debug("DeleteMpak()", "update store");
         if (State != States.Manifest)
             throw new Exception("Cannot delete MPAK, no manifest in store");
 

--- a/Source/Meadow.Core/Cloud/UpdateStore.cs
+++ b/Source/Meadow.Core/Cloud/UpdateStore.cs
@@ -162,7 +162,7 @@ internal class UpdateStore
 
         if (!string.Equals(hashAlgorithm, "meadowCrc", StringComparison.OrdinalIgnoreCase))
         {
-            throw new NotImplementedException();
+            throw new MpakValidationFailedException($"Hash algorithm '{hashAlgorithm}' is not supported.");
         }
 
         mpak_stream?.Dispose();

--- a/Source/Meadow.Core/Cloud/UpdateStore.cs
+++ b/Source/Meadow.Core/Cloud/UpdateStore.cs
@@ -50,10 +50,6 @@ internal class UpdateStore
 
                     if (File.Exists(mpak_path))
                     {
-                        if (GetFileHash(mpak_path) != Manifest.Crc)
-                        {
-                            Log.Warn("MPAK file hash does not match manifest CRC");
-                        }
                         state = States.Mpak;
                     }
                 }
@@ -141,6 +137,39 @@ internal class UpdateStore
             mpak_stream = fi.Create();
         }
         return mpak_stream;
+    }
+
+    internal void DeleteMpak()
+    {
+        Log.Debug("ResetMpak()", "update store");
+        if (State != States.Manifest)
+            throw new Exception("Cannot delete MPAK, no manifest in store");
+
+        File.Delete(mpak_partial_path);
+        File.Delete(mpak_path);
+    }
+
+    internal bool ValidateMpak(string hashAlgorithm, string expectedHash, out string actualHash)
+    {
+        Log.Debug("ValidateMpak()", "update store");
+        if (State != States.Manifest)
+        {
+            throw new Exception("Cannot validate a MPAK, no manifest in store");
+        }
+
+        if (!string.Equals(hashAlgorithm, "meadowCrc", StringComparison.OrdinalIgnoreCase))
+        {
+            throw new NotImplementedException();
+        }
+
+        var mpakFilePath = 
+              File.Exists(mpak_partial_path) ? mpak_partial_path 
+            : File.Exists(mpak_path) ? mpak_path 
+            : throw new FileNotFoundException("Cannot validate a MPAK, no mpak in store");
+
+        actualHash = GetFileHash(mpakFilePath);
+
+        return string.Equals(actualHash, expectedHash, StringComparison.Ordinal);
     }
 
     internal void CompleteMpak()

--- a/Source/Meadow.Core/Cloud/UpdateStore.cs
+++ b/Source/Meadow.Core/Cloud/UpdateStore.cs
@@ -145,6 +145,9 @@ internal class UpdateStore
         if (State != States.Manifest)
             throw new Exception("Cannot delete MPAK, no manifest in store");
 
+        mpak_stream?.Dispose();
+        mpak_stream = null;
+
         File.Delete(mpak_partial_path);
         File.Delete(mpak_path);
     }

--- a/Source/Meadow.Core/Cloud/UpdateStore.cs
+++ b/Source/Meadow.Core/Cloud/UpdateStore.cs
@@ -165,6 +165,9 @@ internal class UpdateStore
             throw new NotImplementedException();
         }
 
+        mpak_stream?.Dispose();
+        mpak_stream = null;
+
         var mpakFilePath = 
               File.Exists(mpak_partial_path) ? mpak_partial_path 
             : File.Exists(mpak_path) ? mpak_path 
@@ -181,7 +184,9 @@ internal class UpdateStore
         if (State != States.Manifest)
             throw new Exception("Cannot add a MPAK, no manifest in store");
 
-        mpak_stream!.Close();
+        mpak_stream?.Dispose();
+        mpak_stream = null;
+
         File.Copy(mpak_partial_path, mpak_path);
         File.Delete(mpak_partial_path);
     }

--- a/Source/Meadow.Core/HttpResponseHeadersExtensions.cs
+++ b/Source/Meadow.Core/HttpResponseHeadersExtensions.cs
@@ -1,0 +1,36 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Net.Http.Headers;
+using System.Text;
+
+namespace System.Net.Http;
+
+internal static class HttpResponseHeadersExtensions
+{
+    public static IEnumerable<ContentDigestItem> GetContentDigests(this HttpResponseHeaders headers)
+    {
+        if (headers == null || !headers.TryGetValues("Content-Digest", out var digestHeaders))
+        {
+            yield break;
+        }
+
+        foreach (var header in digestHeaders)
+        {
+            var values = header.Split(',');
+            foreach (var value in values)
+            {
+                var items = value.Split('=');
+                if (items.Length > 1)
+                {
+                    yield return new ContentDigestItem(items[0].Trim(), items[1].Trim());
+                }
+            }
+        }
+    }
+}
+
+internal class ContentDigestItem(string algorithm, string value)
+{
+    public string Algorithm { get; set; } = algorithm;
+    public string Value { get; set; } = value;
+}

--- a/Source/Meadow.Core/HttpResponseHeadersExtensions.cs
+++ b/Source/Meadow.Core/HttpResponseHeadersExtensions.cs
@@ -30,6 +30,36 @@ internal static class HttpResponseHeadersExtensions
 
         return items;
     }
+
+    public static ContentDigestItem? GetContentDigest(this HttpResponseHeaders headers, string algorithm)
+    {
+        if (headers == null || string.IsNullOrWhiteSpace(algorithm))
+        {
+            return null;
+        }
+
+        var digests = headers.GetContentDigests();
+        foreach (var digest in digests)
+        {
+            if (string.Equals(digest.Algorithm, algorithm, StringComparison.OrdinalIgnoreCase))
+            {
+                return digest;
+            }
+        }
+        return null;
+    }
+
+    public static ContentDigestItem? GetContentDigest(this HttpResponseHeaders headers)
+    {
+        if (headers == null)
+        {
+            return null;
+        }
+
+        var digests = headers.GetContentDigests();
+
+        return digests.Count > 0 ? digests[0] : null;
+    }
 }
 
 internal class ContentDigestItem(string algorithm, string value)

--- a/Source/Meadow.Core/HttpResponseHeadersExtensions.cs
+++ b/Source/Meadow.Core/HttpResponseHeadersExtensions.cs
@@ -7,25 +7,28 @@ namespace System.Net.Http;
 
 internal static class HttpResponseHeadersExtensions
 {
-    public static IEnumerable<ContentDigestItem> GetContentDigests(this HttpResponseHeaders headers)
+    public static IList<ContentDigestItem> GetContentDigests(this HttpResponseHeaders headers)
     {
         if (headers == null || !headers.TryGetValues("Content-Digest", out var digestHeaders))
         {
-            yield break;
+            return Array.Empty<ContentDigestItem>();
         }
 
+        var items = new List<ContentDigestItem>();
         foreach (var header in digestHeaders)
         {
             var values = header.Split(',');
             foreach (var value in values)
             {
-                var items = value.Split('=');
-                if (items.Length > 1)
+                var parts = value.Split('=');
+                if (parts.Length > 1)
                 {
-                    yield return new ContentDigestItem(items[0].Trim(), items[1].Trim());
+                    items.Add(new ContentDigestItem(parts[0].Trim(), parts[1].Trim()));
                 }
             }
         }
+
+        return items;
     }
 }
 

--- a/Source/Meadow.Core/HttpResponseHeadersExtensions.cs
+++ b/Source/Meadow.Core/HttpResponseHeadersExtensions.cs
@@ -20,7 +20,7 @@ internal static class HttpResponseHeadersExtensions
             var values = header.Split(',');
             foreach (var value in values)
             {
-                var parts = value.Split('=');
+                var parts = value.Split('=', 2);
                 if (parts.Length > 1)
                 {
                     items.Add(new ContentDigestItem(parts[0].Trim(), parts[1].Trim()));

--- a/Source/Meadow.Core/MeadowOS.cs
+++ b/Source/Meadow.Core/MeadowOS.cs
@@ -980,14 +980,16 @@ public static partial class MeadowOS
 
         foreach (var d in di.EnumerateDirectories())
         {
-            DeleteDirectoryContents(d, true);
+            DeleteDirectoryContents(d, false);
             if (deleteDirectory)
             {
                 d.Delete();
             }
         }
         if (deleteDirectory)
+        {
             di.Delete();
+        }
     }
 
     /// <summary>

--- a/Source/Meadow.Core/MeadowOS.cs
+++ b/Source/Meadow.Core/MeadowOS.cs
@@ -980,11 +980,7 @@ public static partial class MeadowOS
 
         foreach (var d in di.EnumerateDirectories())
         {
-            DeleteDirectoryContents(d, false);
-            if (deleteDirectory)
-            {
-                d.Delete();
-            }
+            DeleteDirectoryContents(d, deleteDirectory);
         }
         if (deleteDirectory)
         {


### PR DESCRIPTION
This pull request introduces enhanced validation and error handling for file downloads in the update service, focusing on ensuring file integrity and proper handling of partial downloads. The changes add CRC hash validation, improve handling of server responses for resumable downloads, and refactor related methods for clarity and reliability.

**File download and integrity validation improvements:**

* Added CRC hash validation for downloaded files using the new `ValidateMpak` method and `Content-Digest` header parsing, ensuring that downloaded files match expected hashes before completion. [[1]](diffhunk://#diff-fc9883617d906d85a576edd273f75f584b71cf343b7fed58589220973b0dbb54L230-R283) [[2]](diffhunk://#diff-fc9883617d906d85a576edd273f75f584b71cf343b7fed58589220973b0dbb54R325-R357) [[3]](diffhunk://#diff-5443b415134c5cbdb5a3da4e4c8360cd8579f48b6efc8a27c1441ff32ae09842R1-R36) [[4]](diffhunk://#diff-97a7ff780c600fa1b9c842ebb7c2d20cbcc7b9bee7d06b956c8126d245711bd3R142-R174)
* Improved handling of HTTP 416 (Requested Range Not Satisfiable) responses to detect fully downloaded or mismatched files, with appropriate logging and validation.
* Added detailed error handling for download size mismatches and CRC validation failures, including a custom `MpakValidationFailedException` for clearer error reporting and retry logic. [[1]](diffhunk://#diff-fc9883617d906d85a576edd273f75f584b71cf343b7fed58589220973b0dbb54R325-R357) [[2]](diffhunk://#diff-fc9883617d906d85a576edd273f75f584b71cf343b7fed58589220973b0dbb54R446-R456)

**Supporting code and refactoring:**

* Added `DeleteMpak` and `ValidateMpak` methods to `UpdateStore` for managing and verifying downloaded files, and removed redundant hash checks from state transitions. [[1]](diffhunk://#diff-97a7ff780c600fa1b9c842ebb7c2d20cbcc7b9bee7d06b956c8126d245711bd3R142-R174) [[2]](diffhunk://#diff-97a7ff780c600fa1b9c842ebb7c2d20cbcc7b9bee7d06b956c8126d245711bd3L53-L56)
* Introduced `HttpResponseHeadersExtensions` and `ContentDigestItem` for parsing and handling `Content-Digest` HTTP headers.

**Other minor changes:**

* Fixed a bug in `DeleteDirectoryContents` to avoid deleting directories prematurely during recursive deletion.